### PR TITLE
distro/include/rpb.inc: allow GCCVERSION override

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -1,4 +1,4 @@
-GCCVERSION = "linaro-5.2"
+GCCVERSION ?= "linaro-5.2"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"


### PR DESCRIPTION
Allow users to override the choice of compiler to use.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>