### PR TITLE
rpb: add gpsd support

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -5,6 +5,7 @@ GCCVERSION ?= "linaro-5.2"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
+PACKAGECONFIG_remove_pn-gpsd = "qt"
 
 DISTRO_FEATURES_remove = "sysvinit"
 

--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -14,6 +14,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     mesa-demos gtkperf openbox openbox-theme-clearlooks xterm xf86-video-modesetting \
     sshfs-fuse hostapd iptables \
     alsa-utils-aplay gstreamer1.0-plugins-bad-meta gstreamer1.0-plugins-base-meta gstreamer1.0-plugins-good-meta \
+    gpsd gps-utils \
 "
 
 EXTRA_USERS_PARAMS = "\


### PR DESCRIPTION
* add gpsd in our reference images
* disable Qt support in gpsd by default in RPB distros, to avoid bringing Qt
  (especially Qt4) into OE RBP.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>