### PR TITLE
rpb-desktop-image: remove glmark2

### DIFF
--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -15,7 +15,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     connman \
     connman-client \
     coreutils \
-    glmark2 \
     gps-utils \
     gpsd \
     gptfdisk \


### PR DESCRIPTION
In oe-core/master:

ERROR: glmark2 was skipped: Recipe is blacklisted: BROKEN: fails to build with
gcc-6

We will add it back once the issue is fixed.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>