### PR TITLE
rbp: force hardfloat abi for armv7a

### DIFF
--- a/conf/distro/include/arm-defaults.inc
+++ b/conf/distro/include/arm-defaults.inc
@@ -1,0 +1,30 @@
+# This function changes the default tune for machines which
+# are based on armv7a to use common tune value, note that we enforce hard-float
+# which is default on RPB for armv7+
+# so if you have one of those machines which are armv7a but can't support
+# hard-float, please change tune = 'armv7athf' to tune = 'armv7at'
+# below but then this is for your own distro, RPB will not support
+# it
+#
+# Imported from https://github.com/Angstrom-distribution/meta-angstrom/blob/master/conf/distro/include/arm-defaults.inc
+
+def arm_tune_handler(d):
+    features = d.getVar('TUNE_FEATURES', True).split()
+    if 'armv7a' in features:
+        tune = 'armv7athf'
+        if 'bigendian' in features:
+            tune += 'b'
+        if 'vfpv3' in features:
+            tune += '-vfpv3'
+        if 'vfpv3d16' in features:
+            tune += '-vfpv3d16'
+        if 'neon' in features:
+            tune += '-neon'
+        if 'vfpv4' in features:
+            tune += '-vfpv4'
+    else:
+        tune = d.getVar('DEFAULTTUNE', True)
+    return tune
+
+# Should use a distro override 
+DEFAULTTUNE := "${@arm_tune_handler(d)}"

--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -1,5 +1,7 @@
 DISTRO_VERSION = "2.0+linaro"
 
+require conf/distro/include/arm-defaults.inc
+
 GCCVERSION ?= "linaro-5.2"
 
 DISTRO_FEATURES_append = " systemd"


### PR DESCRIPTION
As a bonus this also fixes up anti-social BSPs that force cortex* tunes instead of armv7a ones.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>