### PR TITLE
rbp: move MALI preferred provides to the global include

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -7,6 +7,12 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 
+# FIXME Mali is currently added as a distro config on a per-machine basis
+# This should be automated with an anonymous python method
+PREFERRED_PROVIDER_virtual/egl_hikey = "mali450-userland"
+PREFERRED_PROVIDER_virtual/libgles1_hikey = "mali450-userland"
+PREFERRED_PROVIDER_virtual/libgles2_hikey = "mali450-userland" 
+
 DISTRO_FEATURES_remove = "sysvinit"
 
 DISTRO_FEATURES_append = " opengl pam"

--- a/conf/distro/rpb-wayland.conf
+++ b/conf/distro/rpb-wayland.conf
@@ -4,10 +4,3 @@ DISTRO_NAME = "Reference-Platform-Build-Wayland"
 
 DISTRO_FEATURES_append = " wayland"
 DISTRO_FEATURES_remove = "x11"
-
-# FIXME Mali is currently added as a distro config
-# It could be more approriate to add Mali in HiKey's machine config
-# https://github.com/96boards/meta-96boards/blob/master/conf/machine/hikey.conf
-PREFERRED_PROVIDER_virtual/egl_hikey = "mali450-userland"
-PREFERRED_PROVIDER_virtual/libgles1_hikey = "mali450-userland"
-PREFERRED_PROVIDER_virtual/libgles2_hikey = "mali450-userland" 


### PR DESCRIPTION
EGL is useful for more than wayland. Also remove misguided comment about setting DISTO features in a MACHINE config.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>