### PR TITLE
rpb: whitelist gstreamer1.0-libav license flag

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -9,6 +9,8 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 
+LICENSE_FLAGS_WHITELIST = "commercial_gstreamer1.0-libav"
+
 DISTRO_FEATURES_remove = "sysvinit"
 
 DISTRO_FEATURES_append = " opengl pam"


### PR DESCRIPTION
so that we can use it in RPB based builds.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>