### PR TITLE
rpb: add gstreamer1.0-libav in -desktop and -weston images

### DIFF
--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -21,6 +21,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \
+    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
     gtkperf \
     hostapd \
     iptables \

--- a/recipes-samples/images/rpb-weston-image.bb
+++ b/recipes-samples/images/rpb-weston-image.bb
@@ -25,6 +25,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \
+    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
     hostapd \
     iptables \
     kernel-modules \


### PR DESCRIPTION
The plugins are added only if the appropriate license is whitelisted in the
build environment.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>