### PR TITLE
rpb: move mali magic to global distro, vanilla RPB fails to build without it

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -1,6 +1,7 @@
 DISTRO_VERSION = "2.0+linaro"
 
 require conf/distro/include/arm-defaults.inc
+require conf/distro/include/mali.inc
 
 GCCVERSION ?= "linaro-5.2"
 

--- a/conf/distro/rpb-wayland.conf
+++ b/conf/distro/rpb-wayland.conf
@@ -1,5 +1,4 @@
 require conf/distro/include/rpb.inc
-require conf/distro/include/mali.inc
 
 DISTRO_NAME = "Reference-Platform-Build-Wayland"
 


### PR DESCRIPTION

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>