### PR TITLE
rpd-desktop-image: make sure image is booted until desktop

### DIFF
--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -9,6 +9,10 @@ inherit core-image distro_features_check extrausers
 # let's make sure we have a good image..
 REQUIRED_DISTRO_FEATURES = "x11 pam systemd"
 
+# make sure we boot to desktop
+# by default and without x11-base in IMAGE_FEATURES we default to multi-user.target
+SYSTEMD_DEFAULT_TARGET = "graphical.target"
+
 CORE_IMAGE_BASE_INSTALL += " \
     96boards-tools \
     alsa-utils-aplay \


### PR DESCRIPTION
The default systemd target in our current build is multi-user.target, for the
desktop image we prefer to boot to graphical.target to get the 'desktop'.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>