### PR TITLE
rpb-desktop-image-lava: add piglit test suite

### DIFF
--- a/recipes-samples/images/rpb-desktop-image-lava.bb
+++ b/recipes-samples/images/rpb-desktop-image-lava.bb
@@ -12,4 +12,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     python-scons \
     python-shell \
     python-threading \
+    \
+    piglit \
     "


### PR DESCRIPTION
Add piglit into the image, in order to run piglit test suite in CI loop.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>