### PR TITLE
wpe: making wpe generic & buildable on rpb

### DIFF
--- a/recipes-wpe/wpe/wpe_%.bbappend
+++ b/recipes-wpe/wpe/wpe_%.bbappend
@@ -1,0 +1,9 @@
+# The libprovision turned off, depends on restricted cppsdk component
+PROVISIONING = ""
+
+# these plugins are commercial licensed & removed from build
+RDEPS_EXTRA_remove = " \
+                      gstreamer1.0-plugins-ugly-mpg123 \
+                      gstreamer1.0-plugins-bad-hls \
+                     "
+                     


### PR DESCRIPTION
Removed dependencies which has restricted or commercial license to make it build on rpb