### PR TITLE
gstreamer bad plugins: fix build errors

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.4.4.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.4.4.bbappend
@@ -1,0 +1,2 @@
+# Disable introspection to fix gstinsertbin build issue
+EXTRA_OECONF_append = " --enable-introspection=no"


### PR DESCRIPTION
Disable introspection to fix the gstinsertbin build issue
