### PR TITLE
rpb-qt: qt5/eglfs image (no window manager)

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -8,6 +8,7 @@ GCCVERSION ?= "linaro-5.2"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
+PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 
 LICENSE_FLAGS_WHITELIST = "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264"

--- a/conf/distro/rpb-eglfs.conf
+++ b/conf/distro/rpb-eglfs.conf
@@ -1,0 +1,7 @@
+require conf/distro/include/rpb.inc
+
+DISTRO_NAME = "Reference-Platform-Build-EGLFS"
+
+PACKAGECONFIG_append_pn-qtbase = " eglfs kms"
+
+DISTRO_FEATURES_remove = "wayland x11"

--- a/recipes-samples/images/rpb-qt5-image.bb
+++ b/recipes-samples/images/rpb-qt5-image.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Basic QT5 image"
+
+IMAGE_FEATURES += " package-management debug-tweaks ssh-server-openssh hwcodecs tools-debug"
+
+LICENSE = "MIT"
+
+inherit core-image distro_features_check extrausers
+
+# let's make sure we have a good image..
+REQUIRED_DISTRO_FEATURES = "pam systemd opengl"
+
+# by default and without x11-base in IMAGE_FEATURES we default to multi-user.target
+SYSTEMD_DEFAULT_TARGET = "multi-user.target"
+
+CORE_IMAGE_BASE_INSTALL += " \
+	96boards-tools \
+	alsa-utils-aplay \
+	networkmanager \
+	networkmanager-nmtui \
+	coreutils \
+	gps-utils \
+	gpsd \
+	gptfdisk \
+	gstreamer1.0-plugins-bad-meta \
+	gstreamer1.0-plugins-base-meta \
+	gstreamer1.0-plugins-good-meta \
+	${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
+	hostapd \
+	iptables \
+	kernel-modules \
+	sshfs-fuse \
+	cinematicexperience \
+	qt5everywheredemo \
+	qtbase-examples \
+	${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
+"
+
+EXTRA_USERS_PARAMS = "\
+useradd -p '' linaro; \
+"


### PR DESCRIPTION
This pull requests allows the generation of an image suitable for embedded systems not needing a window manager (x11 or Wayland).

It enables Qt5/eglfs (http://doc.qt.io/qt-5/embedded-linux.html) 

The user can validate the native window using Qt5_CinematicExperience as follows:

$ cd /usr/share/cinematicexperience-1.0/
$ ./Qt5_CinematicExperience --platform eglfs

This commit was tested for the db410c release:
IMAGES=rpb-qt5-image
DISTRO=rpb-qt5

