### PR TITLE
rpb: append flags to LICENSE_FLAGS_WHITELIST

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -10,7 +10,7 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 
-LICENSE_FLAGS_WHITELIST = "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264"
+LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264"
 
 DISTRO_FEATURES_remove = "sysvinit"
 


### PR DESCRIPTION
Instead of setting LICENSE_FLAGS_WHITELIST , let's append to the variable, in
case it is already set with some initial values in any of the local conf/*.conf
files (which are parsed before the $DISTRO .conf file).

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>