### PR TITLE
RPB: switch to multilib by default.

### DIFF
--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -1,0 +1,13 @@
+# This file should be split into distro-${ARCH}-multilib.inc and have a top-level include do 'require  distro-${ARCH}-multilib.inc'.
+# Since BSPs suck pay attentions to the arm-defaults.inc comment below
+
+# Install 64bit into ${prefix}/lib64 and ${prefix}/lib32
+# FIXME: use debian multi-arch style paths
+BASELIB_tune-aarch64 = "lib64"
+BASELIB_tune-armv7ahf-neon = "lib32"
+
+require conf/multilib.conf
+MULTILIBS = "multilib:lib32"
+
+# Merge with conf/distro/inclue/arm-defaults.inc?
+DEFAULTTUNE_virtclass-multilib-lib32 = "armv7ahf-neon"

--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -4,6 +4,7 @@ TARGET_VENDOR = "-linaro"
 
 require conf/distro/include/arm-defaults.inc
 require conf/distro/include/egl.inc
+require conf/distro/include/distro-multilib.inc
 
 GCCVERSION ?= "linaro-5.2"
 


### PR DESCRIPTION
For 32bit machines this change should be transparent, nothing will move. For 64bit machines libs will now be in lib64.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>