### PR TITLE
rpb-*-image-lava: be more conservative and add python-modules

### DIFF
--- a/recipes-samples/images/rpb-console-image-lava.bb
+++ b/recipes-samples/images/rpb-console-image-lava.bb
@@ -7,9 +7,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     \
     python \
     python-misc \
-    python-multiprocessing \
+    python-modules \
     python-numpy \
     python-scons \
-    python-shell \
-    python-threading \
     "

--- a/recipes-samples/images/rpb-desktop-image-lava.bb
+++ b/recipes-samples/images/rpb-desktop-image-lava.bb
@@ -7,11 +7,9 @@ CORE_IMAGE_BASE_INSTALL += " \
     \
     python \
     python-misc \
-    python-multiprocessing \
+    python-modules \
     python-numpy \
     python-scons \
-    python-shell \
-    python-threading \
     \
     piglit \
     "

--- a/recipes-samples/images/rpb-weston-image-lava.bb
+++ b/recipes-samples/images/rpb-weston-image-lava.bb
@@ -7,10 +7,8 @@ CORE_IMAGE_BASE_INSTALL += " \
     \
     python \
     python-misc \
-    python-multiprocessing \
+    python-modules \
     python-numpy \
     python-scons \
-    python-shell \
-    python-threading \
     "
 


### PR DESCRIPTION
Instead of adding only the few modules we might need, let's add them all at
once. These images are test images anyways.

This change also fixes https://validation.linaro.org/scheduler/job/1301682, so
it looks like we were missing some Python features.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>