### PR TITLE
rpb: move to gcc linaro-6.2

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -8,7 +8,7 @@ require conf/distro/include/egl.inc
 # Python3 isn't /lib64 safe
 #require conf/distro/include/distro-multilib.inc
 
-GCCVERSION ?= "linaro-5.2"
+GCCVERSION ?= "linaro-6.2"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"


### PR DESCRIPTION
6.2 is the OE-core default, so let's match that

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>