### PR TITLE
packagegroup-rpb-tests: check for x11 in DISTRO_FEATURES

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -7,7 +7,7 @@ PACKAGES = "\
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-console \
     packagegroup-rpb-tests-python \
-    packagegroup-rpb-tests-x11 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-rpb-tests-x11', '', d)} \
     "
 
 # contains basic dependencies, that don't need graphics/display


### PR DESCRIPTION
We should not add test packages that depend on x11 unconditionally, it was
caught on CI like this:

07:35:30 Parsing of 2626 .bb files complete (0 cached, 2626 parsed). 6060 targets, 1302 skipped, 0 masked, 0 errors.
07:35:30 NOTE: Resolving any missing task queue dependencies
07:35:30 ERROR: Nothing RPROVIDES 'piglit' (but /srv/oe/build/conf/../../layers/meta-rpb/recipes-samples/packagegroups/packagegroup-rpb-tests.bb RDEPENDS on or otherwise requires it)
07:35:30 ERROR: piglit was skipped: missing required distro feature 'x11' (not in DISTRO_FEATURES)

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>