### PR TITLE
distro-multilib.inc: switch libdir naming

### DIFF
--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -3,8 +3,10 @@
 
 # Install 64bit into ${prefix}/lib64 and ${prefix}/lib32
 # FIXME: use debian multi-arch style paths
-BASELIB_tune-aarch64 = "lib64"
+BASELIB_tune-aarch64 = "lib"
+
 BASELIB_tune-armv7ahf-neon = "lib32"
+BASELIB_armv7a = "lib32"
 
 require conf/multilib.conf
 MULTILIBS = "multilib:lib32"


### PR DESCRIPTION
32bit now goes into /lib32, 64bit into /lib. This is a workaround for the broken python3 recipe.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>