### PR TITLE
rpb*-image: create packagegroup to better organize images

### DIFF
--- a/recipes-samples/images/rpb-console-image.bb
+++ b/recipes-samples/images/rpb-console-image.bb
@@ -10,18 +10,7 @@ inherit core-image distro_features_check extrausers
 REQUIRED_DISTRO_FEATURES = "pam systemd"
 
 CORE_IMAGE_BASE_INSTALL += " \
-    96boards-tools \
-    networkmanager \
-    networkmanager-nmtui \
-    coreutils \
-    cpufrequtils \
-    gptfdisk \
-    hostapd \
-    htop \
-    iptables \
-    kernel-modules \
-    sshfs-fuse \
-    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
+    packagegroup-rpb \
 "
 
 EXTRA_USERS_PARAMS = "\

--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -14,32 +14,8 @@ REQUIRED_DISTRO_FEATURES = "x11 pam systemd"
 SYSTEMD_DEFAULT_TARGET = "graphical.target"
 
 CORE_IMAGE_BASE_INSTALL += " \
-    96boards-tools \
-    alsa-utils-aplay \
-    networkmanager \
-    networkmanager-nmtui \
-    coreutils \
-    cpufrequtils \
-    glmark2 \
-    gps-utils \
-    gpsd \
-    gptfdisk \
-    gstreamer1.0-plugins-bad-meta \
-    gstreamer1.0-plugins-base-meta \
-    gstreamer1.0-plugins-good-meta \
-    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
-    gtkperf \
-    hostapd \
-    htop \
-    iptables \
-    kernel-modules \
-    mesa-demos \
-    openbox \
-    openbox-theme-clearlooks \
-    sshfs-fuse \
-    xf86-video-modesetting \
-    xterm \
-    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
+    packagegroup-rpb \
+    packagegroup-rpb-x11 \
 "
 
 EXTRA_USERS_PARAMS = "\

--- a/recipes-samples/images/rpb-weston-image.bb
+++ b/recipes-samples/images/rpb-weston-image.bb
@@ -15,29 +15,8 @@ REQUIRED_DISTRO_FEATURES = "wayland pam systemd"
 #   ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wcnss-config', '', d)}
 # http://git.yoctoproject.org/cgit/cgit.cgi/meta-qcom/tree/conf/machine/dragonboard-410c.conf#n37
 CORE_IMAGE_BASE_INSTALL += " \
-    96boards-tools \
-    alsa-utils-aplay \
-    clutter-1.0-examples \
-    networkmanager \
-    networkmanager-nmtui \
-    coreutils \
-    cpufrequtils \
-    gptfdisk \
-    gstreamer1.0-plugins-bad-meta \
-    gstreamer1.0-plugins-base-meta \
-    gstreamer1.0-plugins-good-meta \
-    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
-    hostapd \
-    htop \
-    iptables \
-    kernel-modules \
-    sshfs-fuse \
-    weston \
-    weston-examples \
-    weston-init \
-    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "mali450", "mali450-userland", "", d)} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "sgx", "libgbm ti-sgx-ddk-km ti-sgx-ddk-um pru-icss", "", d)} \
+    packagegroup-rpb \
+    packagegroup-rpb-weston \
 "
 
 EXTRA_USERS_PARAMS = "\

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -1,0 +1,55 @@
+SUMMARY = "Organize packages to avoid duplication across all images"
+
+inherit packagegroup
+
+PROVIDES = "${PACKAGES}"
+PACKAGES = "\
+    packagegroup-rpb \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-rpb-x11', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'packagegroup-rpb-weston', '', d)} \
+    "
+
+# contains basic dependencies, that can work without graphics/display
+RDEPENDS_packagegroup-rpb = "\
+    96boards-tools \
+    alsa-utils-aplay \
+    coreutils \
+    cpufrequtils \
+    gptfdisk \
+    gps-utils \
+    gpsd \
+    gstreamer1.0-plugins-bad-meta \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
+    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
+    hostapd \
+    htop \
+    iptables \
+    kernel-modules \
+    networkmanager \
+    networkmanager-nmtui \
+    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
+    sshfs-fuse \
+    "
+
+SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
+RDEPENDS_packagegroup-rpb-x11 = "\
+    glmark2 \
+    gtkperf \
+    mesa-demos \
+    openbox \
+    openbox-theme-clearlooks \
+    xf86-video-modesetting \
+    xterm \
+    "
+
+SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
+RDEPENDS_packagegroup-rpb-weston = "\
+    clutter-1.0-examples \
+    weston \
+    weston-examples \
+    weston-init \
+    ${@bb.utils.contains("MACHINE_FEATURES", "mali450", "mali450-userland", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "sgx", "libgbm ti-sgx-ddk-km ti-sgx-ddk-um pru-icss", "", d)} \
+    "
+


### PR DESCRIPTION
To avoid duplication , let's organize our image using packagegroups. There
should be no change for -desktop and -weston images, but in the process we are
adding more packages to -console image (gps, gstreamer, ...) which are valid
packages even for headless images.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>