### PR TITLE
Revert "rbp.inc: disable multilib till bugs are fixed"

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -4,9 +4,7 @@ TARGET_VENDOR = "-linaro"
 
 require conf/distro/include/arm-defaults.inc
 require conf/distro/include/egl.inc
-
-# Python3 isn't /lib64 safe
-#require conf/distro/include/distro-multilib.inc
+require conf/distro/include/distro-multilib.inc
 
 GCCVERSION ?= "linaro-6.2"
 


### PR DESCRIPTION
Not all bugs are fixed, but the main one (python3) is worked around, so reactivate multilib.

This reverts commit 309966ff6ce09b9455e09052d20ca90ee32b0cab.