### PR TITLE
packagegroup: split -rpb into multiple recipes

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Organize packages to avoid duplication across all images (weston)"
+
+inherit packagegroup distro_features_check
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
+RDEPENDS_packagegroup-rpb-weston = "\
+    clutter-1.0-examples \
+    gps-utils \
+    gpsd \
+    gstreamer1.0-plugins-bad-meta \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
+    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
+    weston \
+    weston-examples \
+    weston-init \
+    ${@bb.utils.contains("MACHINE_FEATURES", "mali450", "mali450-userland", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "sgx", "libgbm ti-sgx-ddk-km ti-sgx-ddk-um pru-icss", "", d)} \
+    "
+

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Organize packages to avoid duplication across all images (with X11)"
+
+inherit packagegroup distro_features_check
+REQUIRED_DISTRO_FEATURES = "x11"
+
+SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
+RDEPENDS_packagegroup-rpb-x11 = "\
+    glmark2 \
+    gps-utils \
+    gpsd \
+    gstreamer1.0-plugins-bad-meta \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
+    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
+    gtkperf \
+    mesa-demos \
+    openbox \
+    openbox-theme-clearlooks \
+    xf86-video-modesetting \
+    xterm \
+    "

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -2,13 +2,6 @@ SUMMARY = "Organize packages to avoid duplication across all images"
 
 inherit packagegroup
 
-PROVIDES = "${PACKAGES}"
-PACKAGES = "\
-    packagegroup-rpb \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-rpb-x11', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'packagegroup-rpb-weston', '', d)} \
-    "
-
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\
     96boards-tools \
@@ -17,12 +10,6 @@ RDEPENDS_packagegroup-rpb = "\
     cpufrequtils \
     docker \
     gptfdisk \
-    gps-utils \
-    gpsd \
-    gstreamer1.0-plugins-bad-meta \
-    gstreamer1.0-plugins-base-meta \
-    gstreamer1.0-plugins-good-meta \
-    ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
     hostapd \
     htop \
     iptables \
@@ -33,25 +20,3 @@ RDEPENDS_packagegroup-rpb = "\
     rsync \
     sshfs-fuse \
     "
-
-SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
-RDEPENDS_packagegroup-rpb-x11 = "\
-    glmark2 \
-    gtkperf \
-    mesa-demos \
-    openbox \
-    openbox-theme-clearlooks \
-    xf86-video-modesetting \
-    xterm \
-    "
-
-SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
-RDEPENDS_packagegroup-rpb-weston = "\
-    clutter-1.0-examples \
-    weston \
-    weston-examples \
-    weston-init \
-    ${@bb.utils.contains("MACHINE_FEATURES", "mali450", "mali450-userland", "", d)} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "sgx", "libgbm ti-sgx-ddk-km ti-sgx-ddk-um pru-icss", "", d)} \
-    "
-


### PR DESCRIPTION
Commit 92f304e9133 (rpb*-image: create packagegroup to better organize image)
introduced a regression, since

* packagegroup-rpb recipe is required for -console image, to all packages from
packagegroup-rpb-x11 are built as well, though they are not included in the
image.

* the commit also adds Gstreamer in the -console image. When building -console
with 'x11' enabled, it will bring a lot of X packages regardless of
packagegroup-rpb-x11

As such, we are now doing splitting the packagegroup recipes into multiple
recipes to avoid building packages not needed when building only -console
image, and we remove Gstreamer from -console for now.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>