### PR TITLE
rpb.inc: add ext4.gz image for am57xx-evm machine

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -20,6 +20,10 @@ DISTRO_FEATURES_remove = "sysvinit"
 
 DISTRO_FEATURES_append = " opengl pam"
 
+# am57xx-evm machine config misses ext4.gz image. Add it here.
+IMAGE_FSTYPES_append_am57xx-evm = " ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT_am57xx-evm = "4096"
+
 INHERIT += "rm_work"
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"


### PR DESCRIPTION
am57xx-evm machine config misses ext4.gz image.

Having ext4.gz generated will allow us to boot am57xx-evm board from eMMC.