### PR TITLE
rpb.inc: add ext4.gz image

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -20,6 +20,10 @@ DISTRO_FEATURES_remove = "sysvinit"
 
 DISTRO_FEATURES_append = " opengl pam"
 
+# Fastboot expects an ext4 image, which needs to be 4096 aligned
+IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT = "4096"
+
 INHERIT += "rm_work"
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"


### PR DESCRIPTION
This adds the fragment which is present in hikey and qcom-apq80xx.inc machine configs (in this exact form), but is missing from meta-ti's machine configs.