### PR TITLE
Overlay efivar

### DIFF
--- a/recipes-overlayed/efivar/efivar/0001-efivar-fix-for-cross-compile.patch
+++ b/recipes-overlayed/efivar/efivar/0001-efivar-fix-for-cross-compile.patch
@@ -1,0 +1,35 @@
+From 9a3c480af653b37e62d1be04d49fe7a60a80168f Mon Sep 17 00:00:00 2001
+From: Kai Kang <kai.kang@windriver.com>
+Date: Fri, 25 Sep 2015 18:14:31 +0800
+Subject: [PATCH 1/2] efivar: fix for cross compile
+
+It builds and calls elf file makeguids to generate a header file which
+doesn't work for cross compile. Fix it.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+Upstream-Status: Pending
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ src/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 5fc7887..1829d22 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -29,8 +29,8 @@ all : deps $(TARGETS)
+ ./guid-symbols.c : include/efivar/efivar-guids.h
+ ./guids.bin : include/efivar/efivar-guids.h
+ ./names.bin : include/efivar/efivar-guids.h
+-include/efivar/efivar-guids.h : makeguids guids.txt
+-	./makeguids guids.txt guids.bin names.bin \
++include/efivar/efivar-guids.h : guids.txt
++	makeguids guids.txt guids.bin names.bin \
+ 		guid-symbols.c include/efivar/efivar-guids.h
+ 
+ makeguids : CPPFLAGS+=-DEFIVAR_BUILD_ENVIRONMENT
+-- 
+2.4.3
+

--- a/recipes-overlayed/efivar/efivar/0003-efivar-fix-for-cross-compile.patch
+++ b/recipes-overlayed/efivar/efivar/0003-efivar-fix-for-cross-compile.patch
@@ -1,0 +1,44 @@
+From 7ead29ca6bb5e280ae07551cc3521281ecf73682 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Sat, 7 May 2016 02:06:47 -0400
+Subject: [PATCH] Makefile: fix efivar.pc not found
+
+It fixes efivar.pc not found:
+...
+| install -d -m 755 efivar/0.23-r0/image/usr/lib/pkgconfig/
+| install -m 644 efivar.pc efivar/0.23-r0/image/usr/lib/pkgconfig/
+;  install -m 644 efiboot.pc efivar/0.23-r0/image/usr/lib/pkgconfig/
+;
+| install: cannot stat 'efivar.pc': No such file or directory
+| install: cannot stat 'efiboot.pc': No such file or directory
+| make[1]: *** [install] Error 1
+| make[1]: Leaving directory `efivar/0.23-r0/git/src'
+| make: *** [install] Error 2
+| ERROR: oe_runmake failed
+...
+
+Upstream-Status: Pending
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ src/Makefile | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index c7a0ca3..ad9c427 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -78,7 +78,9 @@ install : all
+ 		ln -fs $(x).$(VERSION) $(DESTDIR)$(libdir)/$(x).$(MAJOR_VERSION);\
+ 		ln -fs $(x).$(VERSION) $(DESTDIR)$(libdir)/$(x); )
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(PCDIR)
+-	$(foreach x, $(PCTARGETS), $(INSTALL) -m 644 $(x) $(DESTDIR)$(PCDIR) ;)
++	$(foreach x, $(PCTARGETS), $(INSTALL) -m 644 $(TOPDIR)/src/$(x).in $(DESTDIR)$(PCDIR)/$(x) ;\
++		sed -i -e "s:@@LIBDIR@@:$(libdir):g" -e "s:@@VERSION@@:$(VERSION):g" \
++			$(DESTDIR)$(PCDIR)/$(x); )
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(includedir)/efivar
+ 	$(foreach x, $(wildcard $(TOPDIR)/src/include/efivar/*.h), $(INSTALL) -m 644 $(x) $(DESTDIR)$(includedir)/efivar/$(notdir $(x));)
+ 	$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
+-- 
+2.8.1
+

--- a/recipes-overlayed/efivar/efivar/allow-multi-definitions-for-native.patch
+++ b/recipes-overlayed/efivar/efivar/allow-multi-definitions-for-native.patch
@@ -1,0 +1,23 @@
+Upstream-Status: Pending
+
+It fails to create .so file when build efivar-native:
+
+| lib.o:(*IND*+0x0): multiple definition of `efi_set_variable'
+| lib.o:lib.c:(.text+0xa0): first defined here
+
+Add link option '-z muldefs' to fix it.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+diff --git a/Make.rules b/Make.rules
+index d9c0609..874bce0 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -20,6 +20,7 @@ include $(TOPDIR)/Make.version
+ 	$(CCLD) $(ccldflags) $(CPPFLAGS) $(SOFLAGS) \
+ 	  -Wl,-soname,$@.$(MAJOR_VERSION) \
+ 	  -Wl,--version-script=$(MAP) \
++	  -Wl,-z,muldefs \
+ 	  -o $@ $^ $(LDLIBS)
+ 
+ %.o : %.c

--- a/recipes-overlayed/efivar/efivar_0.30.bb
+++ b/recipes-overlayed/efivar/efivar_0.30.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Tools to manipulate UEFI variables"
+DESCRIPTION = "efivar provides a simple command line interface to the UEFI variable facility"
+HOMEPAGE = "https://github.com/rhinstaller/efivar"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6626bb1e20189cfa95f2c508ba286393"
+
+DEPENDS = "popt"
+DEPENDS_append_class-target = " efivar-native"
+
+COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
+
+SRCREV = "270205d88598d60d4e75f9cec13b8d25d82ee550"
+SRC_URI = "git://github.com/rhinstaller/efivar.git \
+"
+SRC_URI_append_class-target = " file://0001-efivar-fix-for-cross-compile.patch \
+                                file://0003-efivar-fix-for-cross-compile.patch \
+                              "
+SRC_URI_append_class-native = " \ 
+                                file://allow-multi-definitions-for-native.patch \
+                              "
+
+S = "${WORKDIR}/git"
+
+# Setting CROSS_COMPILE breaks pkgconfig, so just set AR
+EXTRA_OEMAKE = "AR=${TARGET_PREFIX}gcc-ar"
+
+do_compile_prepend() {
+    sed -i -e s:-Werror::g ${S}/gcc.specs
+}
+
+do_install() {
+    oe_runmake install DESTDIR=${D}
+}
+
+do_install_append_class-native() {
+    install -D -m 0755 ${B}/src/makeguids ${D}${bindir}/makeguids
+}
+
+BBCLASSEXTEND = "native"
+


### PR DESCRIPTION
Efivar fails to build with a recent libc-headers, so overlay it till it gets accepted into meta-oe.