### PR TITLE
rpb.inc: change GCCVERSION for linaro-6.%

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -18,7 +18,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "linaro-6.2"
+GCCVERSION ?= "linaro-6.%"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"


### PR DESCRIPTION
Meta-linaro-toolchain switched to 6.3, so fix the '6.2 is missing' errors and try to future proof it a bit.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>