### PR TITLE
packagegroup-rpb: remove docker from armv7a hardware

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -2,13 +2,16 @@ SUMMARY = "Organize packages to avoid duplication across all images"
 
 inherit packagegroup
 
+DOCKER = "docker"
+DOCKER_armv7a = ""
+
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\
     96boards-tools \
     alsa-utils-aplay \
     coreutils \
     cpufrequtils \
-    docker \
+    ${DOCKER} \
     gptfdisk \
     hostapd \
     htop \


### PR DESCRIPTION
While docker can run on arm 32bit, we prefer to focus on arm 64bit
devices. If some users express interest in having docker on arm 32bit, we
can revisit.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>