### PR TITLE
eglfs with Qt5.8: add gbm to PACKAGECONFIG

### DIFF
--- a/conf/distro/rpb-eglfs.conf
+++ b/conf/distro/rpb-eglfs.conf
@@ -2,6 +2,6 @@ require conf/distro/include/rpb.inc
 
 DISTRO_NAME = "Reference-Platform-Build-EGLFS"
 
-PACKAGECONFIG_append_pn-qtbase = " eglfs kms"
+PACKAGECONFIG_append_pn-qtbase = " eglfs kms gbm"
 
 DISTRO_FEATURES_remove = "wayland x11"


### PR DESCRIPTION
bugfix for "EGL_EXT_device_base missing"
gbm is needed for the creation of  the  libqeglfs-kms-integration.so plugin