### PR TITLE
distro-multilib.inc: fix libdir for armv8

### DIFF
--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -3,7 +3,7 @@
 
 # Install 64bit into ${prefix}/lib64 and ${prefix}/lib32
 # FIXME: use debian multi-arch style paths
-BASELIB_arch64 = "lib"
+BASELIB_aarch64 = "lib"
 
 BASELIB_tune-armv7ahf-neon = "lib32"
 BASELIB_armv7a = "lib32"

--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -3,7 +3,7 @@
 
 # Install 64bit into ${prefix}/lib64 and ${prefix}/lib32
 # FIXME: use debian multi-arch style paths
-BASELIB_tune-aarch64 = "lib"
+BASELIB_arch64 = "lib"
 
 BASELIB_tune-armv7ahf-neon = "lib32"
 BASELIB_armv7a = "lib32"


### PR DESCRIPTION
The Yocto Project docs keep using tune-foo, which doesn't work, so fall back to something that does work.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>