### PR TITLE
packagegroup-rpb-tests: remove python-scons

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -25,7 +25,6 @@ RDEPENDS_packagegroup-rpb-tests-python = "\
     python-numpy \
     python-pexpect \
     python-pyyaml \
-    python-scons \
     "
 
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"


### PR DESCRIPTION
I haven't found where it is used in LAVA, test-runner or QA test
definitions, so remove it for now. We'll re-add if it's really required.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>