### PR TITLE
Fine tune packages installed by default

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -22,17 +22,14 @@ include ${@get_multilib_handler(d)}
 
 GCCVERSION ?= "linaro-6.%"
 
-DISTRO_FEATURES_append = " systemd"
+DISTRO_FEATURES_append = " opengl pam systemd"
+DISTRO_FEATURES_remove = "sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 
 LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264 non-commercial"
-
-DISTRO_FEATURES_remove = "sysvinit"
-
-DISTRO_FEATURES_append = " opengl pam"
 
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES_remove = "tar.gz"

--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -23,7 +23,7 @@ include ${@get_multilib_handler(d)}
 GCCVERSION ?= "linaro-6.%"
 
 DISTRO_FEATURES_append = " opengl pam systemd"
-DISTRO_FEATURES_remove = "sysvinit"
+DISTRO_FEATURES_remove = "3g sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"

--- a/recipes-samples/images/rpb-console-image.bb
+++ b/recipes-samples/images/rpb-console-image.bb
@@ -13,6 +13,9 @@ CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb \
 "
 
+# docker pulls runc/containerd, which in turn recommend lxc unecessarily
+BAD_RECOMMENDATIONS_append = " lxc"
+
 EXTRA_USERS_PARAMS = "\
 useradd -p '' linaro; \
 "


### PR DESCRIPTION
Attempt to reduce the images size by removing unnecessary packages like ofono, lxc and their dependencies.