### PR TITLE
rpb.inc: remove rm_work by default

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -34,7 +34,6 @@ LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg comm
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES_remove = "tar.gz"
 
-INHERIT += "rm_work"
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"


### PR DESCRIPTION
Let the user define that as a build-system option instead of forcing as
a default distro option.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>