### PR TITLE
rpb: enable kms in gstreamer -bad plugins set

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,6 +28,7 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
+PACKAGECONFIG_append_pn-gstreamer1.0-plugins-bad = " kms"
 
 LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264 non-commercial"
 


### PR DESCRIPTION
This will enable kmssink which can be used for rendering video without X11 , nor
wayland.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>