### PR TITLE
[rfc] piglit: work around errors on GBM and EGL.

### DIFF
--- a/recipes-overlayed/piglit/piglit/0001-Forget-about-GBM_BO_MAP.patch
+++ b/recipes-overlayed/piglit/piglit/0001-Forget-about-GBM_BO_MAP.patch
@@ -1,0 +1,31 @@
+From 35c407f24a05664be9276b03fd498eaa3975c148 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 4 May 2017 00:57:39 -0500
+Subject: [PATCH] Forget about GBM_BO_MAP.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 983f4a3..8140314 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -141,10 +141,6 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+ 	if(GBM_FOUND)
+ 		set(PIGLIT_HAS_GBM True)
+ 		add_definitions(-DPIGLIT_HAS_GBM)
+-		if (GBM_VERSION VERSION_EQUAL "12.1" OR GBM_VERSION VERSION_GREATER "12.1")
+-			set(PIGLIT_HAS_GBM_BO_MAP True)
+-			add_definitions(-DPIGLIT_HAS_GBM_BO_MAP)
+-		endif()
+ 	endif(GBM_FOUND)
+ 
+ 	pkg_check_modules(WAYLAND QUIET wayland-client wayland-egl)
+-- 
+1.9.1
+

--- a/recipes-overlayed/piglit/piglit/0002-Don-t-try-to-test-egl_mesa_platform_surfaceless.patch
+++ b/recipes-overlayed/piglit/piglit/0002-Don-t-try-to-test-egl_mesa_platform_surfaceless.patch
@@ -1,0 +1,28 @@
+From bcd9f4b4381a5e3102ec741ff4948ad9743b8c82 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 4 May 2017 01:28:52 -0500
+Subject: [PATCH] Don't try to test egl_mesa_platform_surfaceless.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ tests/egl/spec/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/egl/spec/CMakeLists.txt b/tests/egl/spec/CMakeLists.txt
+index 66d76db..efebf3b 100644
+--- a/tests/egl/spec/CMakeLists.txt
++++ b/tests/egl/spec/CMakeLists.txt
+@@ -7,7 +7,6 @@ add_subdirectory (egl_khr_get_all_proc_addresses)
+ add_subdirectory (egl_khr_gl_image)
+ add_subdirectory (egl_khr_fence_sync)
+ add_subdirectory (egl_khr_surfaceless_context)
+-add_subdirectory (egl_mesa_platform_surfaceless)
+ 
+ if (PIGLIT_HAS_X11)
+ 	add_subdirectory (egl_chromium_sync_control)
+-- 
+1.9.1
+

--- a/recipes-overlayed/piglit/piglit_%.bbappend
+++ b/recipes-overlayed/piglit/piglit_%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI += "file://0001-Forget-about-GBM_BO_MAP.patch \
+            file://0002-Don-t-try-to-test-egl_mesa_platform_surfaceless.patch \
+"
+DEPENDS += "virtual/egl"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
More information can be found here:
  https://projects.linaro.org/browse/BB-418

First patch is about Piglit assuming GBM includes gbm_bo_map()
and gbm_bo_unmap() because of GBM's major version (>= 12.1),
but this turns out not to be the case with our Mali binary.

Second patch regards the lack of eglGetPlatformDisplay (and
other related symbols), which do exist as their EXT counter-
parts in Mali (eglGetPlatformDisplayEXT, etc.). This failure
is about testing eglGetPlatformDisplay, so the patch removes
the test entirely.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>