### PR TITLE
distro-multilib.inc: enfore RPM as package format

### DIFF
--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -13,3 +13,7 @@ MULTILIBS = "multilib:lib32"
 
 # Merge with conf/distro/inclue/arm-defaults.inc?
 DEFAULTTUNE_virtclass-multilib-lib32 = "armv7ahf-neon"
+
+# Enforce RPM, opkg and dpkg can't parallel install multilib conflicts
+PACKAGE_CLASSES = "package_rpm"
+

--- a/recipes-samples/images/rpb-multilib-image.bb
+++ b/recipes-samples/images/rpb-multilib-image.bb
@@ -1,0 +1,7 @@
+require rpb-minimal-image.bb
+
+SUMMARY = "Minimal multilib image"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    bash lib32-bash \
+"


### PR DESCRIPTION
Opkg can't do file-level conflict resolution for multilib, so switch to RPM.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>