### PR TITLE
tests: add python-pip

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -24,6 +24,7 @@ RDEPENDS_packagegroup-rpb-tests-python = "\
     python-modules \
     python-numpy \
     python-pexpect \
+    python-pip \
     python-pyyaml \
     "
 


### PR DESCRIPTION
For some LAVA tests, such as the ui-browser-test, which
require installing software via pip, this is about enough to
get everything in working order.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>