### PR TITLE
distro-multilib: switch around lib/lib{32,64} again

### DIFF
--- a/conf/distro/include/distro-multilib.inc
+++ b/conf/distro/include/distro-multilib.inc
@@ -3,10 +3,10 @@
 
 # Install 64bit into ${prefix}/lib64 and ${prefix}/lib32
 # FIXME: use debian multi-arch style paths
-BASELIB_aarch64 = "lib"
+#BASELIB_aarch64 = "lib"
 
 BASELIB_tune-armv7ahf-neon = "lib32"
-BASELIB_armv7a = "lib32"
+BASELIB_armv7a = "lib"
 
 require conf/multilib.conf
 MULTILIBS = "multilib:lib32"


### PR DESCRIPTION
Both '/lib' and '/lib64' are builtin defaults for gcc, 'lib32' isn't. Some recipes (e.g. shadow) will fail to build when using non-builtin paths.

Another problem is that the '/lib' assignment here was partially overriden to '/lib64' by OE-core, so comment that assignment as well.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>