### PR TITLE
packagegroup-rpb: use bb.utils.contains to filter out docker

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -2,16 +2,13 @@ SUMMARY = "Organize packages to avoid duplication across all images"
 
 inherit packagegroup
 
-DOCKER = "docker"
-DOCKER_armv7a = ""
-
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\
     96boards-tools \
     alsa-utils-aplay \
     coreutils \
     cpufrequtils \
-    ${DOCKER} \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "docker", d)} \
     gptfdisk \
     hostapd \
     htop \


### PR DESCRIPTION
The current approach prevents to use:
 RDEPENDS_packagegroup-rpb_remove = "docker"

It's causing the following error:
 Computing transaction...error: Can't install packagegroup-rpb-1.0-r0@all:
 no package provides docker

Use bitbake's utils.contains function to filter out docker, instead of the
current approach and allow to use RDEPENDS_packagegroup-rpb.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>