### PR TITLE
python-pexpect: import from OE-core

### DIFF
--- a/recipes-devtools/python/python-pexpect_4.2.1.bb
+++ b/recipes-devtools/python/python-pexpect_4.2.1.bb
@@ -1,0 +1,28 @@
+SUMMARY = "A Pure Python Expect like Module for Python"
+HOMEPAGE = "http://pexpect.readthedocs.org/"
+SECTION = "devel/python"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1c7a725251880af8c6a148181665385b"
+
+SRCNAME = "pexpect"
+
+SRC_URI = "https://files.pythonhosted.org/packages/source/p/${SRCNAME}/${SRCNAME}-${PV}.tar.gz"
+SRC_URI[md5sum] = "3694410001a99dff83f0b500a1ca1c95"
+SRC_URI[sha256sum] = "3d132465a75b57aa818341c6521392a06cc660feb3988d7f1074f39bd23c9a92"
+
+UPSTREAM_CHECK_URI = "https://pypi.python.org/pypi/pexpect"
+
+S = "${WORKDIR}/pexpect-${PV}"
+
+inherit setuptools
+
+RDEPENDS_${PN} = "\
+    python-core \
+    python-io \
+    python-terminal \
+    python-resource \
+    python-fcntl \
+    python-ptyprocess \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python-ptyprocess_0.5.1.bb
+++ b/recipes-devtools/python/python-ptyprocess_0.5.1.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Run a subprocess in a pseudo terminal"
+HOMEPAGE = "http://ptyprocess.readthedocs.io/en/latest/"
+SECTION = "devel/python"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cfdcd51fa7d5808da4e74346ee394490"
+
+SRCNAME = "ptyprocess"
+
+SRC_URI = "https://files.pythonhosted.org/packages/source/p/${SRCNAME}/${SRCNAME}-${PV}.tar.gz"
+SRC_URI[md5sum] = "94e537122914cc9ec9c1eadcd36e73a1"
+SRC_URI[sha256sum] = "0530ce63a9295bfae7bd06edc02b6aa935619f486f0f1dc0972f516265ee81a6"
+
+UPSTREAM_CHECK_URI = "https://pypi.python.org/pypi/ptyprocess"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+inherit setuptools
+
+RDEPENDS_${PN} = "\
+    python-core \
+"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
OE-core rev 701ac8e558c9c09cdab2306ebc416f0070585b11 removed the recipe, but we still depend on it, so import it.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>