### PR TITLE
packagegroup-rpb-{x11,weston}: add kmscube

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -12,6 +12,7 @@ RDEPENDS_packagegroup-rpb-weston = "\
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \
     ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
+    kmscube \
     weston \
     weston-examples \
     weston-init \

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -14,6 +14,7 @@ RDEPENDS_packagegroup-rpb-x11 = "\
     gstreamer1.0-plugins-good-meta \
     ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial_gstreamer1.0-libav", "gstreamer1.0-libav", "", d)} \
     gtkperf \
+    kmscube \
     mesa-demos \
     openbox \
     openbox-theme-clearlooks \


### PR DESCRIPTION
kmscube is a very convenient graphic test app, and it is always useful to have
it handy. Adding kmscube in packagegroup-rpb instead would bring mesa and
gstreamer in the headless console image which is probably not a good idea. so
adding it in the graphical images only.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>