### PR TITLE
kselftests: add recipes for mainline and linux-kselftest next branch

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -1,0 +1,31 @@
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# kernel selftests dependencies
+DEPENDS = "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+"
+
+inherit kernel-arch
+
+KSELFTESTS_ARGS = "-C ${S}/tools/testing/selftests INSTALL_PATH=${D}${INSTALL_PATH} CC="${CC}" LD="${LD}" ARCH=${ARCH}"
+
+do_compile() {
+    # Make sure to install the user space API used by some tests
+    # but not properly declared as a build dependency
+    ${MAKE} -C ${S} ARCH=${ARCH} headers_install
+    ${MAKE} ${KSELFTESTS_ARGS}
+}
+
+do_install() {
+    ${MAKE} ${KSELFTESTS_ARGS} install
+    chown -R root:root ${D}
+    # fixup run_kselftest.sh due to spurious lines starting by "make[1]:"
+    sed -i '/^make/d' ${D}${INSTALL_PATH}/run_kselftest.sh
+}
+
+FILES_${PN} = "${INSTALL_PATH}"
+FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug"
+
+RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 ncurses sudo"
+
+INSANE_SKIP_${PN} = "already-stripped"

--- a/recipes-overlayed/kselftests/kselftests-mainline_4.12.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.12.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Linux Kernel Selftests (mainline)"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+
+SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz"
+# Patches inappropriate or not yet merged by upstream
+# Some patches may have been submitted to upstream
+SRC_URI += "\
+    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
+    file://0001-selftests-breakpoints-re-order-TEST_GEN_PROGS-target.patch \
+    file://0001-selftests-gpio-fix-build-error.patch \
+    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
+    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch;apply=no \
+    file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch;apply=no \
+    file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0001-selftests-splice-fix-installation-for-splice-test.patch \
+"
+
+SRC_URI[md5sum] = "fc454157e2d024d401a60905d6481c6b"
+SRC_URI[sha256sum] = "a45c3becd4d08ce411c14628a949d08e2433d8cdeca92036c7013980e93858ab"
+
+S = "${WORKDIR}/linux-${PV}"
+
+export INSTALL_PATH = "/opt/kselftests/mainline"
+
+require kselftests-common.inc

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Linux Kernel Selftests (linux-kselftest next)"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+SRCREV = "43c6437453f2e777da306c81c1cb47612e21e972"
+
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git;protocol=https;branch=next;name=kernel"
+# Patches inappropriate or not yet merged by upstream
+# Some patches may have been submitted to upstream
+SRC_URI += "\
+    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
+    file://0001-selftests-breakpoints-re-order-TEST_GEN_PROGS-target.patch \
+    file://0001-selftests-gpio-fix-build-error.patch \
+    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
+    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch;apply=no \
+    file://0001-selftests-splice-fix-installation-for-splice-test.patch;apply=no \
+"
+
+S = "${WORKDIR}/git"
+
+export INSTALL_PATH = "/opt/kselftests/next"
+
+require kselftests-common.inc


### PR DESCRIPTION
Since they share common bits to compile/install, add an include to carry
the common code.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>