### PR TITLE
rpb.inc: ensure ext4.gz rootfs is generated for omap-15 family

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -43,6 +43,10 @@ LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg comm
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES_remove = "tar.gz"
 
+# By default, meta-ti and TI SDK ship tar.xz rootfs tarball for SD card deployment
+# fastboot is preferred for deployment in automation
+IMAGE_FSTYPES_append_omap-a15 = " ext4.gz"
+
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"


### PR DESCRIPTION
By default, meta-ti and TI SDK ship tar.xz rootfs tarball for SD card
deployment. fastboot is preferred for deployment in automation.
Ensure we generate ext4.gz image for omap-15 family (like Beagle x15), so
we can flash sparse images with fastboot.

Due to the order of the includes, set this configuration in DISTRO.conf.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>