### PR TITLE
packagegroup-rpb-tests.bb: Use IMAGE_FEATURES instead of DISTRO_FEATU…

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -7,7 +7,7 @@ PACKAGES = "\
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-console \
     packagegroup-rpb-tests-python \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-rpb-tests-x11', '', d)} \
+    ${@bb.utils.contains('IMAGE_FEATURES', 'x11', 'packagegroup-rpb-tests-x11', '', d)} \
     "
 
 # contains basic dependencies, that don't need graphics/display


### PR DESCRIPTION
…RES for x11

The DISTRO_FEATURES var by default enables x11 see DISTRO_FEATURES_DEFAULT
var, we have the rpb-console-image and the rpb-desktop-image that uses
rpb DISTRO.

The rpb-console-image doesn't actually require x11 so test of x11 in
IMAGE_FEATURES to avoid unnecessary long builds (chromedriver -> chromium -> x11).

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>