### PR TITLE
conf/distro: Set GCCVERSION to use gcc 7.1 from Linaro

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,7 +28,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "linaro-6.%"
+GCCVERSION ?= "linaro-7.%"
 
 DISTRO_FEATURES_append = " opengl pam systemd"
 DISTRO_FEATURES_remove = "3g sysvinit"


### PR DESCRIPTION
The next oe-core (rocko) release is using gcc 7.X realese.

Tested building rpb-minimal-image for db410c.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>