### PR TITLE
rpb: add ffmpeg (and ffplay)

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -37,6 +37,7 @@ PACKAGECONFIG_append_pn-systemd = " resolved networkd"
 PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 PACKAGECONFIG_append_pn-gstreamer1.0-plugins-bad = " kms"
+PACKAGECONFIG_append_pn-ffmpeg = " sdl2"
 
 LICENSE_FLAGS_WHITELIST += "commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264"
 

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -6,6 +6,7 @@ REQUIRED_DISTRO_FEATURES = "x11"
 SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
 RDEPENDS_packagegroup-rpb-x11 = "\
     chromium \
+    ffmpeg \
     glmark2 \
     gps-utils \
     gpsd \


### PR DESCRIPTION
Now that we have v4l2 codecs support in ffmpeg, let's add it into the image, by
default.

ffplay is a nice utility to play video using ffmpeg, but it requires sdl2
support, so let's add that too.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>