### PR TITLE
packagegroup-rpb-tests: add stress-ng on console tests

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -30,4 +30,5 @@ RDEPENDS_packagegroup-rpb-tests-python = "\
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"
 RDEPENDS_packagegroup-rpb-tests-console = "\
     ltp \
+    stress-ng \
     "


### PR DESCRIPTION
When running tests plans with test-runner some tests requires
to have free space, so add 1 GB for now to avoid Out of space
problems.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>