### PR TITLE
recipes-samples/images: RPB Lava images adds 32MB extra space

### DIFF
--- a/recipes-samples/images/rpb-console-image-lava.bb
+++ b/recipes-samples/images/rpb-console-image-lava.bb
@@ -1,5 +1,7 @@
 require rpb-console-image.bb
 
+IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     "

--- a/recipes-samples/images/rpb-desktop-image-lava.bb
+++ b/recipes-samples/images/rpb-desktop-image-lava.bb
@@ -1,5 +1,7 @@
 require rpb-desktop-image.bb
 
+IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-x11 \

--- a/recipes-samples/images/rpb-weston-image-lava.bb
+++ b/recipes-samples/images/rpb-weston-image-lava.bb
@@ -1,5 +1,7 @@
 require rpb-weston-image.bb
 
+IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     "


### PR DESCRIPTION
LAVA copies the test overlay before boot and the image ran out
of space during this process [1].

The lava-dispatcher logic copies the test scripts and cases inside
rootfs before boot mounting the rootfs partition. I tested this changes
see apply-overlay-sparse-image in [2].

[1] https://staging.validation.linaro.org/scheduler/job/194060
[2] https://staging.validation.linaro.org/scheduler/job/194183

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>