### PR TITLE
images/rpb-*-lava: Increase the extra size to 1GB

### DIFF
--- a/recipes-samples/images/rpb-console-image-lava.bb
+++ b/recipes-samples/images/rpb-console-image-lava.bb
@@ -1,6 +1,6 @@
 require rpb-console-image.bb
 
-IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \

--- a/recipes-samples/images/rpb-desktop-image-lava.bb
+++ b/recipes-samples/images/rpb-desktop-image-lava.bb
@@ -1,6 +1,6 @@
 require rpb-desktop-image.bb
 
-IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \

--- a/recipes-samples/images/rpb-weston-image-lava.bb
+++ b/recipes-samples/images/rpb-weston-image-lava.bb
@@ -1,6 +1,6 @@
 require rpb-weston-image.bb
 
-IMAGE_ROOTFS_EXTRA_SPACE = "32768"
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \


### PR DESCRIPTION
The space ran out when we added other smoke tests WLAN/HCI [1],
after review the actual size of test overlay in lt-qcom build is
358M [2].

The reason is because LAVA copies the test definition repository for
every entry in test, the actual size of the test-definitions repository
is around 25M, and we have currently 14 tests declared.

LAVA needs to improve the way to handle the same repository with
different tests (symlinks) or providing support to test plans.

[1] https://staging.validation.linaro.org/scheduler/job/195319
[2]
https://staging.validation.linaro.org/scheduler/job/195319/definition#defline89

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>