### PR TITLE
rpb: Add support for ptest in -lava images

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -30,7 +30,7 @@ include ${@get_multilib_handler(d)}
 
 GCCVERSION ?= "linaro-7.%"
 
-DISTRO_FEATURES_append = " opengl pam systemd"
+DISTRO_FEATURES_append = " opengl pam systemd ptest"
 DISTRO_FEATURES_remove = "3g sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-systemd = " resolved networkd"

--- a/recipes-samples/images/rpb-console-image-lava.bb
+++ b/recipes-samples/images/rpb-console-image-lava.bb
@@ -2,6 +2,8 @@ require rpb-console-image.bb
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
+EXTRA_IMAGE_FEATURES += "ptest-pkgs"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     "

--- a/recipes-samples/images/rpb-desktop-image-lava.bb
+++ b/recipes-samples/images/rpb-desktop-image-lava.bb
@@ -2,6 +2,8 @@ require rpb-desktop-image.bb
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
+EXTRA_IMAGE_FEATURES += "ptest-pkgs"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-x11 \

--- a/recipes-samples/images/rpb-weston-image-lava.bb
+++ b/recipes-samples/images/rpb-weston-image-lava.bb
@@ -1,6 +1,7 @@
 require rpb-weston-image.bb
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
+EXTRA_IMAGE_FEATURES += "ptest-pkgs"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \

--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,4 +32,5 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-speakertest \
     ltp \
     stress-ng \
+    ptest-runner \
     "


### PR DESCRIPTION
The package test (ptest) enables support to run unittests
of packages into the DUT.

The rpb distro now enables to build ptest packages via
DISTRO_FEATURE ptest, this will cause to build ptest
packages in recipes that have support. [1]

In -lava images the ptest-runner and the ptests packages
are installed by default.

[1] https://wiki.yoctoproject.org/wiki/Ptest

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>