### PR TITLE
packagegroup-rpb-tests: Add python3-misc and python3-modules

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -7,6 +7,7 @@ PACKAGES = "\
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-console \
     packagegroup-rpb-tests-python \
+    packagegroup-rpb-tests-python3 \
     "
 
 # contains basic dependencies, that don't need graphics/display
@@ -14,6 +15,7 @@ RDEPENDS_packagegroup-rpb-tests = "\
     packagegroup-core-buildessential \
     packagegroup-rpb-tests-console \    
     packagegroup-rpb-tests-python \
+    packagegroup-rpb-tests-python3 \
     "
 
 SUMMARY_packagegroup-rpb-tests-python = "Python support for running tests"
@@ -25,6 +27,13 @@ RDEPENDS_packagegroup-rpb-tests-python = "\
     python-pexpect \
     python-pip \
     python-pyyaml \
+    "
+
+SUMMARY_packagegroup-rpb-tests-python3 = "Python3 support for running tests"
+RDEPENDS_packagegroup-rpb-tests-python3 = "\
+    python3 \
+    python3-misc \
+    python3-modules \
     "
 
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"


### PR DESCRIPTION
The Python3 intepreter is already installed (via bluez dep) in the
image but without python3-misc and python3-modules, isn't usable.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>