### PR TITLE
packagegroup-rpb-weston: add ffmpeg (and ffplay)

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -8,6 +8,7 @@ RDEPENDS_packagegroup-rpb-weston = "\
     chromium-wayland \
     chromium-wayland-chromedriver \
     clutter-1.0-examples \
+    ffmpeg \
     gps-utils \
     gpsd \
     gstreamer1.0-plugins-bad-meta \


### PR DESCRIPTION
ffmpeg and ffplay have been recently added to packagegroup-rpb-x11. They
are worth adding to the weston images as well.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>