### PR TITLE
packagegroup-rpb-tests-x11: Add gst-validate and xvfb

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -9,4 +9,6 @@ PACKAGES = "\
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
     chromium-chromedriver \
     piglit \
+    gst-validate \
+    xserver-xorg-xvfb \
     "


### PR DESCRIPTION
The gst-validate serves to test gstreamer components and it
needs xvfb to run without display attached.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>