### PR TITLE
kselftests: upgrade to 4.14

### DIFF
--- a/recipes-overlayed/kselftests/files/0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch
+++ b/recipes-overlayed/kselftests/files/0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch
@@ -100,19 +100,17 @@ libpthread.
 
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 ---
- tools/testing/selftests/seccomp/Makefile |    4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ tools/testing/selftests/seccomp/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 --- a/tools/testing/selftests/seccomp/Makefile
 +++ b/tools/testing/selftests/seccomp/Makefile
-@@ -1,8 +1,8 @@
- TEST_GEN_PROGS := seccomp_bpf
+@@ -9,7 +9,7 @@ BINARIES := seccomp_bpf seccomp_benchmark
  CFLAGS += -Wl,-no-as-needed -Wall
--LDFLAGS += -lpthread
-+LDLIBS += -lpthread
  
- include ../lib.mk
+ seccomp_bpf: seccomp_bpf.c ../kselftest_harness.h
+-	$(CC) $(CFLAGS) $(LDFLAGS) -lpthread $< -o $@
++	$(CC) $(CFLAGS) $(LDFLAGS) $< -lpthread -o $@
  
- $(TEST_GEN_PROGS): seccomp_bpf.c ../kselftest_harness.h
--	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@
-+	$(CC) $(CFLAGS) $(LDFLAGS) $< $(LDLIBS) -o $@
+ TEST_PROGS += $(BINARIES)
+ EXTRA_CLEAN := $(BINARIES)

--- a/recipes-overlayed/kselftests/files/0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch
+++ b/recipes-overlayed/kselftests/files/0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch
@@ -54,14 +54,14 @@ libpthread.
 Signed-off-by: Denys Dmytriyenko <denys@ti.com>
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 ---
- tools/testing/selftests/timers/Makefile |    2 +-
+ tools/testing/selftests/timers/Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 --- a/tools/testing/selftests/timers/Makefile
 +++ b/tools/testing/selftests/timers/Makefile
 @@ -1,6 +1,6 @@
- BUILD_FLAGS = -DKTEST
- CFLAGS += -O3 -Wl,-no-as-needed -Wall $(BUILD_FLAGS)
+ # SPDX-License-Identifier: GPL-2.0
+ CFLAGS += -O3 -Wl,-no-as-needed -Wall
 -LDFLAGS += -lrt -lpthread -lm
 +LDLIBS += -lrt -lpthread -lm
  

--- a/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
@@ -7,17 +7,15 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz"
 # Some patches may have been submitted to upstream
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
-    file://0001-selftests-breakpoints-re-order-TEST_GEN_PROGS-target.patch \
     file://0001-selftests-gpio-fix-build-error.patch \
     file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
-    file://0001-selftests-splice-fix-installation-for-splice-test.patch \
 "
 
-SRC_URI[md5sum] = "ab1a2abc6f37b752dd2595338bec4e78"
-SRC_URI[sha256sum] = "2db3d6066c3ad93eb25b973a3d2951e022a7e975ee2fa7cbe5bddf84d9a49a2c"
+SRC_URI[md5sum] = "bacdb9ffdcd922aa069a5e1520160e24"
+SRC_URI[sha256sum] = "f81d59477e90a130857ce18dc02f4fbe5725854911db1e7ba770c7cd350f96a7"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
* Update md5sum/sha256sum for 4.14 tarball
* Drop patches merged upstream:
  - 0001-selftests-breakpoints-re-order-TEST_GEN_PROGS-target.patc
  - 0001-selftests-splice-fix-installation-for-splice-test.patch
* Refresh patches:
  - 0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch
  - 0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>