### PR TITLE
recipe-samples: add a packagegroup and an image for LKFT

### DIFF
--- a/recipes-samples/images/rpb-console-image-lkft.bb
+++ b/recipes-samples/images/rpb-console-image-lkft.bb
@@ -1,0 +1,11 @@
+require rpb-console-image.bb
+
+SUMMARY = "Basic console image for LKFT"
+
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    packagegroup-core-tools-debug \
+    packagegroup-rpb-tests \
+    packagegroup-rpb-lkft \
+    "

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Organize packages to avoid duplication across all images"
+
+inherit packagegroup
+
+# contains basic dependencies for LKFT
+RDEPENDS_packagegroup-rpb-lkft = "\
+    cpupower \
+    git \
+    kernel-selftests \
+    kselftests-mainline \
+    kselftests-next \
+    libhugetlbfs-tests \
+    mosh-server \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+    "


### PR DESCRIPTION
The LKFT image is close to the LAVA image with 3 main differences:
* ptest isn't enabled in the image features
* contains additional packages provided by the LKFT package group
* include packagegroup-core-tools-debug

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>