### PR TITLE
recipes-overlayed: selftests: bpf: Adding config fragment CONFIG_CGROUP_BPF=y

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-bpf-Adding-config-fragment-CONFIG_CGROUP_B.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-bpf-Adding-config-fragment-CONFIG_CGROUP_B.patch
@@ -1,0 +1,26 @@
+From 63060c39161d3d61c771dee20a3cbdffaf83f1df Mon Sep 17 00:00:00 2001
+From: Naresh Kamboju <naresh.kamboju@linaro.org>
+Date: Tue, 12 Dec 2017 00:55:23 +0530
+Subject: [PATCH 1/8] selftests: bpf: Adding config fragment
+ CONFIG_CGROUP_BPF=y
+
+CONFIG_CGROUP_BPF=y is required for test_dev_cgroup test case.
+
+Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+---
+ tools/testing/selftests/bpf/config | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/testing/selftests/bpf/config b/tools/testing/selftests/bpf/config
+index 52d53ed..9d48973 100644
+--- a/tools/testing/selftests/bpf/config
++++ b/tools/testing/selftests/bpf/config
+@@ -3,3 +3,4 @@ CONFIG_BPF_SYSCALL=y
+ CONFIG_NET_CLS_BPF=m
+ CONFIG_BPF_EVENTS=y
+ CONFIG_TEST_BPF=m
++CONFIG_CGROUP_BPF=y
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
@@ -12,6 +12,7 @@ SRC_URI += "\
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0001-selftests-bpf-Adding-config-fragment-CONFIG_CGROUP_B.patch \
 "
 
 SRC_URI[md5sum] = "bacdb9ffdcd922aa069a5e1520160e24"

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -14,6 +14,7 @@ SRC_URI += "\
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0001-selftests-bpf-Adding-config-fragment-CONFIG_CGROUP_B.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Adding the upstream accepted here.

selftests: bpf: Adding config fragment CONFIG_CGROUP_BPF=y
Ref:
tree: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
commit id: 63060c39161d3d61c771dee20a3cbdffaf83f1df

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>