### PR TITLE
kselftests-common.inc: add bpf/*.o files into FILES_${PN}

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -24,9 +24,16 @@ do_install() {
 }
 
 FILES_${PN} = "${INSTALL_PATH}"
+# The bpf tests depend on that the object files are installed as well.
+# OE wont throw an error if files do not exist.
+FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug"
 
 RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 glibc-utils ncurses sudo"
 RDEPENDS_append_x86 = " cpupower"
 
 INSANE_SKIP_${PN} = "already-stripped"
+# Ignore the QA error because kselftests/bpf/ requires object files
+# ERROR message:
+# ERROR: kselftests-mainline-4.14-r0 do_package_qa: QA Issue: Architecture did not match (Unknown (0), expected AArch64) on /work/hikey-linaro-linux/kselftests-mainline/4.14-r0/packages-split/kselftests-mainline/opt/kselftests/mainline/bpf/test_tcp_estats.o
+ERROR_QA_remove = "arch"


### PR DESCRIPTION
Fix bpf/ tests:
libbpf: failed to open ./test_pkt_access.o: No such file or directory
libbpf: failed to open ./test_xdp.o: No such file or directory
libbpf: failed to open ./test_l4lb.o: No such file or directory
libbpf: failed to open ./test_tcp_estats.o: No such file or directory
test_tcp_estats:FAIL: err -2 errno 2
test_bpf_obj_id:PASS:get-fd-by-notexist-prog-id 0 nsec
test_bpf_obj_id:PASS:get-fd-by-notexist-map-id 0 nsec
libbpf: failed to open ./test_obj_id.o: No such file or directory
test_progs: test_progs.c:317: test_bpf_obj_id: Assertion `!err' failed.
Aborted (core dumped)

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>