### PR TITLE
kselftests: move to version 4.14.10

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-mainline_4.14.10.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.14.10.bb
@@ -14,8 +14,8 @@ SRC_URI += "\
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 
-SRC_URI[md5sum] = "bacdb9ffdcd922aa069a5e1520160e24"
-SRC_URI[sha256sum] = "f81d59477e90a130857ce18dc02f4fbe5725854911db1e7ba770c7cd350f96a7"
+SRC_URI[md5sum] = "cfab8ee2ee4eb6600a1e7da33a2ff275"
+SRC_URI[sha256sum] = "86baf1374ca003bdd9a43cae7f59cec02b455a6c38c3705aa46b2b68d91ed110"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
Test case ldt_gdt was changed in 4.14.10. This change is not backward
compatible and the tests from previous versions fail on the new kernel
code. Only one test case was changed so this patch should be safe for
other results.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>