### PR TITLE
kselftests-common: RDEPEND cpupower

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -27,5 +27,6 @@ FILES_${PN} = "${INSTALL_PATH}"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug"
 
 RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 glibc-utils ncurses sudo"
+RDEPENDS_append_x86 = " cpupower"
 
 INSANE_SKIP_${PN} = "already-stripped"


### PR DESCRIPTION
test intel_pstate uses cpupower, add that to RDEPEND

cd /opt/kselftests/default-in-kernel/intel_pstate
./run.sh
./run.sh: line 79: cpupower: command not found

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>