### PR TITLE
kselftests-mainline_4.14: Adding missing kselftest test patch

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-x86-ldt-Prevent-LDT-inheritance-on-exec.patch
+++ b/recipes-overlayed/kselftests/files/0001-x86-ldt-Prevent-LDT-inheritance-on-exec.patch
@@ -1,0 +1,73 @@
+From 2c8e9099aecec2baaac8d34c7b823493f2d0eeed Mon Sep 17 00:00:00 2001
+From: Thomas Gleixner <tglx@linutronix.de>
+Date: Thu, 14 Dec 2017 12:27:31 +0100
+Subject: [PATCH] x86/ldt: Prevent LDT inheritance on exec
+
+commit a4828f81037f491b2cc986595e3a969a6eeb2fb5 upstream.
+
+The LDT is inherited across fork() or exec(), but that makes no sense
+at all because exec() is supposed to start the process clean.
+
+The reason why this happens is that init_new_context_ldt() is called from
+init_new_context() which obviously needs to be called for both fork() and
+exec().
+
+It would be surprising if anything relies on that behaviour, so it seems to
+be safe to remove that misfeature.
+
+Split the context initialization into two parts. Clear the LDT pointer and
+initialize the mutex from the general context init and move the LDT
+duplication to arch_dup_mmap() which is only called on fork().
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Peter Zijlstra <peterz@infradead.org>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Andy Lutomirsky <luto@kernel.org>
+Cc: Boris Ostrovsky <boris.ostrovsky@oracle.com>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Borislav Petkov <bpetkov@suse.de>
+Cc: Brian Gerst <brgerst@gmail.com>
+Cc: Dave Hansen <dave.hansen@intel.com>
+Cc: Dave Hansen <dave.hansen@linux.intel.com>
+Cc: David Laight <David.Laight@aculab.com>
+Cc: Denys Vlasenko <dvlasenk@redhat.com>
+Cc: Eduardo Valentin <eduval@amazon.com>
+Cc: Greg KH <gregkh@linuxfoundation.org>
+Cc: H. Peter Anvin <hpa@zytor.com>
+Cc: Josh Poimboeuf <jpoimboe@redhat.com>
+Cc: Juergen Gross <jgross@suse.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Will Deacon <will.deacon@arm.com>
+Cc: aliguori@amazon.com
+Cc: dan.j.williams@intel.com
+Cc: hughd@google.com
+Cc: keescook@google.com
+Cc: kirill.shutemov@linux.intel.com
+Cc: linux-mm@kvack.org
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+diff --git a/tools/testing/selftests/x86/ldt_gdt.c b/tools/testing/selftests/x86/ldt_gdt.c
+index 66e5ce5..0304ffb 100644
+--- a/tools/testing/selftests/x86/ldt_gdt.c
++++ b/tools/testing/selftests/x86/ldt_gdt.c
+@@ -627,13 +627,10 @@ static void do_multicpu_tests(void)
+ static int finish_exec_test(void)
+ {
+ 	/*
+-	 * In a sensible world, this would be check_invalid_segment(0, 1);
+-	 * For better or for worse, though, the LDT is inherited across exec.
+-	 * We can probably change this safely, but for now we test it.
++	 * Older kernel versions did inherit the LDT on exec() which is
++	 * wrong because exec() starts from a clean state.
+ 	 */
+-	check_valid_segment(0, 1,
+-			    AR_DPL3 | AR_TYPE_XRCODE | AR_S | AR_P | AR_DB,
+-			    42, true);
++	check_invalid_segment(0, 1);
+ 
+ 	return nerrs ? 1 : 0;
+ }
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
@@ -12,6 +12,7 @@ SRC_URI += "\
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0001-x86-ldt-Prevent-LDT-inheritance-on-exec.patch \
 "
 
 SRC_URI[md5sum] = "bacdb9ffdcd922aa069a5e1520160e24"


### PR DESCRIPTION
This patch landed in to stable-rc-4.14 but the kselftest we are using is missing
this patch so adding this now as an extra patch.
NOTE: This patch would be removed when we upgrade kselftest to 4.15 mainline

Ref:
Thomas Gleixner <tglx@linutronix.de>
    x86/ldt: Prevent LDT inheritance on exec

The bug we have is due to old test case code vs latest kernel source code.
kselftests: ldt_gdt_64 fails on x86
https://bugs.linaro.org/show_bug.cgi?id=3564

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>