### PR TITLE
conf/distro: rpb.inc: create ext4.gz to use in qemu

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -48,6 +48,9 @@ IMAGE_FSTYPES_remove = "tar.gz"
 # fastboot is preferred for deployment in automation
 IMAGE_FSTYPES_append_omap-a15 = " ext4.gz"
 
+# Add ext4.gz rootfs for use it in qemu.
+IMAGE_FSTYPES_append_juno = " ext4.gz"
+
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"


### PR DESCRIPTION
Use Junos rootfs.ext4.gz to run LKFT tests using QEMU.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>