### PR TITLE
kselftests-mainline_4.14: Adding missing kselftest x86 ldt_gdt test p…

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-x86-ldt-Make-the-LDT-mapping-RO.patch
+++ b/recipes-overlayed/kselftests/files/0001-x86-ldt-Make-the-LDT-mapping-RO.patch
@@ -1,0 +1,55 @@
+From e08acdb9620bcd4c55128cad07e625cd1825e533 Mon Sep 17 00:00:00 2001
+From: Thomas Gleixner <tglx@linutronix.de>
+Date: Fri, 15 Dec 2017 20:35:11 +0100
+Subject: [PATCH] x86/ldt: Make the LDT mapping RO
+
+commit 9f5cb6b32d9e0a3a7453222baaf15664d92adbf2 upstream.
+
+Now that the LDT mapping is in a known area when PAGE_TABLE_ISOLATION is
+enabled its a primary target for attacks, if a user space interface fails
+to validate a write address correctly. That can never happen, right?
+
+The SDM states:
+
+    If the segment descriptors in the GDT or an LDT are placed in ROM, the
+    processor can enter an indefinite loop if software or the processor
+    attempts to update (write to) the ROM-based segment descriptors. To
+    prevent this problem, set the accessed bits for all segment descriptors
+    placed in a ROM. Also, remove operating-system or executive code that
+    attempts to modify segment descriptors located in ROM.
+
+So its a valid approach to set the ACCESS bit when setting up the LDT entry
+and to map the table RO. Fixup the selftest so it can handle that new mode.
+
+Remove the manual ACCESS bit setter in set_tls_desc() as this is now
+pointless. Folded the patch from Peter Ziljstra.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Dave Hansen <dave.hansen@linux.intel.com>
+Cc: H. Peter Anvin <hpa@zytor.com>
+Cc: Josh Poimboeuf <jpoimboe@redhat.com>
+Cc: Juergen Gross <jgross@suse.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+diff --git a/tools/testing/selftests/x86/ldt_gdt.c b/tools/testing/selftests/x86/ldt_gdt.c
+index 0304ffb..1aef72d 100644
+--- a/tools/testing/selftests/x86/ldt_gdt.c
++++ b/tools/testing/selftests/x86/ldt_gdt.c
+@@ -122,8 +122,7 @@ static void check_valid_segment(uint16_t index, int ldt,
+ 	 * NB: Different Linux versions do different things with the
+ 	 * accessed bit in set_thread_area().
+ 	 */
+-	if (ar != expected_ar &&
+-	    (ldt || ar != (expected_ar | AR_ACCESSED))) {
++	if (ar != expected_ar && ar != (expected_ar | AR_ACCESSED)) {
+ 		printf("[FAIL]\t%s entry %hu has AR 0x%08X but expected 0x%08X\n",
+ 		       (ldt ? "LDT" : "GDT"), index, ar, expected_ar);
+ 		nerrs++;
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.14.bb
@@ -13,6 +13,7 @@ SRC_URI += "\
     file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0001-x86-ldt-Prevent-LDT-inheritance-on-exec.patch \
+    file://0001-x86-ldt-Make-the-LDT-mapping-RO.patch \
 "
 
 SRC_URI[md5sum] = "bacdb9ffdcd922aa069a5e1520160e24"


### PR DESCRIPTION
…atch

This patch landed in to stable-rc-4.14 but the kselftest we are using is missing
this patch so adding this now as an extra patch.
NOTE: This patch would be removed when we upgrade kselftest to 4.15 mainline

Ref:
x86/ldt: Make the LDT mapping RO
https://patchwork.kernel.org/patch/10117475/

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>