### PR TITLE
recipes-samples: Add rpb-initramfs-image{,-test}

### DIFF
--- a/recipes-samples/images/rpb-initramfs-image-test.bb
+++ b/recipes-samples/images/rpb-initramfs-image-test.bb
@@ -1,0 +1,3 @@
+require rpb-initramfs-image.bb
+
+IMAGE_INSTALL += "stress-ng"

--- a/recipes-samples/images/rpb-initramfs-image.bb
+++ b/recipes-samples/images/rpb-initramfs-image.bb
@@ -1,0 +1,38 @@
+SUMMARY = "RPB Initramfs image for kernel boot testing"
+DESCRIPTION = "Small image capable of booting a device."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+BAD_RECOMMENDATIONS += "busybox-syslog"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} ${INITRAMFS_FSTYPES}.u-boot"
+
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = ""
+
+# List of packages to install
+IMAGE_INSTALL = "\
+  base-passwd \
+  bash \
+  busybox \
+  bzip2 \
+  dhcp-client \
+  dosfstools \
+  e2fsprogs \
+  e2fsprogs-mke2fs \
+  gptfdisk \
+  gzip \
+  rpb-boot-initramfs \
+  net-tools \
+  parted \
+  tar \
+  u-boot-mkimage \
+  wget \
+  "
+
+# Keep extra language files from being installed
+IMAGE_LINGUAS = ""
+
+IMAGE_ROOTFS_SIZE = "8192"
+
+inherit core-image

--- a/recipes-samples/initrdscripts/files/init.sh
+++ b/recipes-samples/initrdscripts/files/init.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+HOME=/root
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+PS1="linaro-test [rc=$(echo \$?)]# "
+export HOME PS1 PATH
+
+early_setup() {
+    mkdir -p /proc /sys /tmp /run
+    mount -t proc proc /proc
+    mount -t sysfs sysfs /sys
+    mount -t devtmpfs none /dev
+
+    ln -s /run /var/run
+
+    chmod 0666 /dev/tty*
+    chown root:tty /dev/tty*
+}
+
+read_args() {
+    [ -z "$CMDLINE" ] && CMDLINE=`cat /proc/cmdline`
+    for arg in $CMDLINE; do
+        optarg=`expr "x$arg" : 'x[^=]*=\(.*\)'`
+        case $arg in
+            console=*)
+                tty=${arg#console=}
+                tty=${tty#/dev/}
+
+                case $tty in
+                    tty[a-zA-Z]* )
+                        port=${tty%%,*}
+                esac ;;
+            debug) set -x ;;
+        esac
+    done
+}
+
+early_setup
+read_args
+
+setsid sh </dev/${port} >/dev/${port} 2>&1

--- a/recipes-samples/initrdscripts/rpb-boot-initramfs_1.0.bb
+++ b/recipes-samples/initrdscripts/rpb-boot-initramfs_1.0.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "Simple init script for RPB initramfs image"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://init.sh"
+
+do_install() {
+        install -m 0755 ${WORKDIR}/init.sh ${D}/init
+}
+
+inherit allarch
+
+FILES_${PN} += " /init "


### PR DESCRIPTION
In order to provide support of ramdisk images to make kernel testing.

This recipes are heavily based on meta-initramfs (initramfs-debug{,image}
[1][2], add our own to don't depend on meta-initramfs layer and to make
customizations easily (changed the init (/ -> /sbin).

The LAVA image only contains stress-ng for now, later we will add simple
tools to test the kernel.

[1] http://layers.openembedded.org/layerindex/recipe/33578/
[2] http://layers.openembedded.org/layerindex/recipe/33579/

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>