### PR TITLE
recipes-overlayed: Add busybox bbappend to enable setsid

### DIFF
--- a/recipes-overlayed/busybox/busybox_1.%.bbappend
+++ b/recipes-overlayed/busybox/busybox_1.%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://enable-setsid-tty.cfg"

--- a/recipes-overlayed/busybox/files/enable-setsid-tty.cfg
+++ b/recipes-overlayed/busybox/files/enable-setsid-tty.cfg
@@ -1,0 +1,1 @@
+CONFIG_SETSID=y


### PR DESCRIPTION
Using linaro-image-minimal-initramfs fails at init (kernel panic)
because setsid isn't available,

...
/init: line 41: setsid: command not found
[    2.769969] Kernel panic - not syncing: Attempted to kill init!
exitcode=0x00007f00
...

A previous discussion was made to enable conditionally via
DISTRO_FEATURES [1] but the patch wasn't integrated because the common
way is to use a bbappend.

This will enable setsid on all busybox builds that includes meta-rpb
layer, the size of the busybox build will increase ~2000 bytes.

[1] https://patchwork.openembedded.org/patch/29813/

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>