### PR TITLE
packagegroup-rpb-weston: account for the new chromium-wayland recipe …

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -5,8 +5,8 @@ REQUIRED_DISTRO_FEATURES = "wayland"
 
 SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS_packagegroup-rpb-weston = "\
-    chromium-wayland \
-    chromium-wayland-chromedriver \
+    chromium-ozone-wayland \
+    chromium-ozone-wayland-chromedriver \
     clutter-1.0-examples \
     ffmpeg \
     gps-utils \


### PR DESCRIPTION
packagegroup-rpb-weston.bb needs the change similar to #140.

This will fix the failures like https://ci.linaro.org/view/reference-platform/job/96boards-reference-platform-openembedded-master/DISTRO=rpb-wayland,MACHINE=dragonboard-410c,label=docker-stretch-amd64/510/console