### PR TITLE
kseftests-next_git: update PV to 4.15

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Linux Kernel Selftests (linux-kselftest next)"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
-PV = "4.14+git${SRCPV}"
+PV = "4.15+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel"


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>