### PR TITLE
packagegroup-rpb-tests-x11: fix ChromeDriver for X11's package name

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -7,7 +7,7 @@ PACKAGES = "\
     packagegroup-rpb-tests-x11 \
     "
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
-    chromium-chromedriver \
+    chromium-x11-chromedriver \
     gst-validate \
     piglit \
     xserver-xorg-xvfb \


### PR DESCRIPTION
A recent change in meta-browser renamed the recipe from
chromium to chromium-x11; the chromedriver package derived
from that package name and thus had its name changed too.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>