### PR TITLE
kselftests: depend on clang-native for BPF target

### DIFF
--- a/recipes-overlayed/clang/clang_git.bbappend
+++ b/recipes-overlayed/clang/clang_git.bbappend
@@ -1,0 +1,3 @@
+EXTRA_OECMAKE_append_class-native = "\
+               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;BPF;Mips;PowerPC;X86' \
+"

--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -1,7 +1,7 @@
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # kernel selftests dependencies
-DEPENDS = "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux \
+DEPENDS = "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
 "
 


### PR DESCRIPTION
Some .o files needed by the bpf selftests were not being
produced because version 3.7+ of Clang was needed, with
support for the BPF target.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>