### PR TITLE
recipe-samples: add a packagegroup and an image for LKFT

### DIFF
--- a/recipes-samples/images/rpb-console-image-lkft.bb
+++ b/recipes-samples/images/rpb-console-image-lkft.bb
@@ -1,0 +1,10 @@
+require rpb-console-image.bb
+
+SUMMARY = "Basic console image for LKFT"
+
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    packagegroup-rpb-tests \
+    packagegroup-rpb-lkft \
+    "

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Organize packages to avoid duplication across all images"
+
+inherit packagegroup
+
+# contains basic dependencies for LKFT
+RDEPENDS_packagegroup-rpb-lkft = "\
+    git \
+    kernel-selftests \
+    kselftests-mainline \
+    kselftests-next \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+    "

--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -30,6 +30,8 @@ RDEPENDS_packagegroup-rpb-tests-python = "\
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"
 RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-speakertest \
+    cpupower \
+    libhugetlbfs-tests \
     ltp \
     stress-ng \
     ptest-runner \


### PR DESCRIPTION
The LKFT image is close to the LAVA image with 2 main differences:
* ptest isn't enabled in the image features
* contains additional packages provided by the LKFT package group

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>