### PR TITLE
chromium-x11: put the missing patch back

### DIFF
--- a/recipes-overlayed/chromium/files/0001-memcpy-used-without-including-string.h.patch
+++ b/recipes-overlayed/chromium/files/0001-memcpy-used-without-including-string.h.patch
@@ -1,0 +1,39 @@
+Upstream-Status: Backport
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+---
+From 4942f56ceb6d60d6f54ebca8e6eba8ba01c278e8 Mon Sep 17 00:00:00 2001
+From: Tomas Popela <tomas.popela@gmail.com>
+Date: Thu, 7 Dec 2017 22:33:34 +0000
+Subject: [PATCH] memcpy used without including string.h
+
+Compiling Chromium with Clang 4.0.1 and using libstdc++ will fail on using
+memcpy without including string.h.
+
+Cq-Include-Trybots: master.tryserver.blink:linux_trusty_blink_rel;master.tryserver.chromium.android:android_optional_gpu_tests_rel
+Change-Id: Idced1d5de3baf6b520d4a2d61774120642ead1a8
+Reviewed-on: https://chromium-review.googlesource.com/813737
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Reviewed-by: vmpstr <vmpstr@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#522579}
+---
+ cc/paint/raw_memory_transfer_cache_entry.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cc/paint/raw_memory_transfer_cache_entry.cc b/cc/paint/raw_memory_transfer_cache_entry.cc
+index 9e4660c685ee..95ad50b1a338 100644
+--- a/cc/paint/raw_memory_transfer_cache_entry.cc
++++ b/cc/paint/raw_memory_transfer_cache_entry.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "cc/paint/raw_memory_transfer_cache_entry.h"
+ 
++#include <string.h>
++
+ namespace cc {
+ 
+ ClientRawMemoryTransferCacheEntry::ClientRawMemoryTransferCacheEntry(
+-- 
+2.14.3
+


### PR DESCRIPTION
The below patch has been merged upstream, and is already present in
chromium-ozone-wayland_65.0.3315.0.
But chromium-x11_64.0.3282.167 recipe still needs it.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>