### PR TITLE
rpb-initramfs-image-test: Changes to make image suitable for boot regression testing

### DIFF
--- a/recipes-overlayed/busybox/busybox_1.%.bbappend
+++ b/recipes-overlayed/busybox/busybox_1.%.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://enable-setsid-tty.cfg"
+SRC_URI += "file://enable-install.cfg"

--- a/recipes-overlayed/busybox/files/enable-install.cfg
+++ b/recipes-overlayed/busybox/files/enable-install.cfg
@@ -1,0 +1,1 @@
+CONFIG_INSTALL=y

--- a/recipes-samples/images/rpb-initramfs-image-test.bb
+++ b/recipes-samples/images/rpb-initramfs-image-test.bb
@@ -1,3 +1,3 @@
 require rpb-initramfs-image.bb
 
-IMAGE_INSTALL += "stress-ng"
+IMAGE_INSTALL += "make stress-ng"

--- a/recipes-samples/images/rpb-initramfs-image.bb
+++ b/recipes-samples/images/rpb-initramfs-image.bb
@@ -27,6 +27,7 @@ IMAGE_INSTALL = "\
   parted \
   tar \
   u-boot-mkimage \
+  udev \
   wget \
   "
 

--- a/recipes-samples/initrdscripts/files/init.sh
+++ b/recipes-samples/initrdscripts/files/init.sh
@@ -5,16 +5,32 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 PS1="linaro-test [rc=$(echo \$?)]# "
 export HOME PS1 PATH
 
+do_mount_fs() {
+   grep -q "$1" /proc/filesystems || return
+   test -d "$2" || mkdir -p "$2"
+   mount -t "$1" "$1" "$2"
+}
+
+do_mknod() {
+    test -e "$1" || mknod "$1" "$2" "$3" "$4"
+}
+
 early_setup() {
     mkdir -p /proc /sys /tmp /run
     mount -t proc proc /proc
-    mount -t sysfs sysfs /sys
-    mount -t devtmpfs none /dev
+
+    do_mount_fs sysfs /sys
+    do_mount_fs debugfs /sys/kernel/debug
+    do_mount_fs devtmpfs /dev
+    do_mount_fs devpts /dev/pts
+    do_mount_fs tmpfs /dev/shm
 
     ln -s /run /var/run
 
     chmod 0666 /dev/tty*
     chown root:tty /dev/tty*
+
+    /sbin/udevd --daemon
 }
 
 read_args() {


### PR DESCRIPTION
The udev support is needed for some tests [1] also is good to have
automatic device node handling.

Add debugfs, devpts and tmpfs filesystems based on [2].

[1] https://github.com/andersson/bootrr
[2]
https://github.com/andersson/meta-stuff/blob/master/recipes-bsp/initrdscripts/files/init-debug.sh

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>