### PR TITLE
packagegroup: some packagegroups are MACHINE_ARCH

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -3,6 +3,8 @@ SUMMARY = "Organize packages to avoid duplication across all images (weston)"
 inherit packagegroup distro_features_check
 REQUIRED_DISTRO_FEATURES = "wayland"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS_packagegroup-rpb-weston = "\
     chromium-ozone-wayland \

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -2,6 +2,8 @@ SUMMARY = "Organize packages to avoid duplication across all images"
 
 inherit packagegroup
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\
     96boards-tools \


### PR DESCRIPTION
packagegroup are most of the time (and by default) arch:all, however in this
specific case, we have dependencies on MACHINE features, so that makes the
packages MACHINE_ARCH. While it does not 'fix' any build issue, it helps the
package feed and sstate.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>