### PR TITLE
recipes-samples/packagegroups: Fixes order to set PACKAGE_ARCH

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -1,9 +1,9 @@
 SUMMARY = "Organize packages to avoid duplication across all images (weston)"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit packagegroup distro_features_check
 REQUIRED_DISTRO_FEATURES = "wayland"
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS_packagegroup-rpb-weston = "\

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -1,8 +1,8 @@
 SUMMARY = "Organize packages to avoid duplication across all images"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\


### PR DESCRIPTION
Fixes,

ERROR: Please ensure recipe
/srv/oe/build/conf/../../layers/meta-rpb/recipes-samples/packagegroups/packagegroup-rpb.bb
sets PACKAGE_ARCH before inherit packagegroup

In,

https://ci.linaro.org/job/lt-qcom-openembedded-rpb-rocko/DISTRO=rpb,MACHINE=dragonboard-410c,label=docker-stretch-amd64/95/console

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>