### PR TITLE
Add Python3 modules for tests

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -30,6 +30,7 @@ FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 glibc-utils ncurses sudo"
+RDEPENDS_${PN} =+ "python3-argparse python3-datetime python3-json python3-pprint python3-subprocess"
 RDEPENDS_${PN}_append_x86 = " cpupower"
 RDEPENDS_${PN}_append_x86-64 = " cpupower"
 


### PR DESCRIPTION
Some Python3 modules needed for tests here (LAVA ptest) and there (kselftests' BPF).

These two commits can be shared with Rocko.