### PR TITLE
Revert "clang: enable support for BPF target"

### DIFF
--- a/recipes-overlayed/clang/clang_git.bbappend
+++ b/recipes-overlayed/clang/clang_git.bbappend
@@ -1,3 +1,0 @@
-EXTRA_OECMAKE_append_class-native = "\
-               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;BPF;Mips;PowerPC;X86' \
-"


### PR DESCRIPTION
This reverts commit c888d0084072da5f5881ca14e1a4ef5f57e4dcca,
since the changes have now been appliend to upstream
meta-clang:
  https://github.com/kraj/meta-clang/commit/63cdfebb47be639e3aff22f3592c238f3c3b495c

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>