### PR TITLE
[morty] Revert "clang: enable support for BPF target"

### DIFF
--- a/recipes-overlayed/clang/clang_git.bbappend
+++ b/recipes-overlayed/clang/clang_git.bbappend
@@ -1,3 +1,0 @@
-EXTRA_OECMAKE_append_class-native = "\
-               -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;BPF;Mips;PowerPC;X86' \
-"


### PR DESCRIPTION
This reverts commit d6a35dd84be434af104b579a9e8481a6cae12bc9,
since the changes have now been appliend to upstream
meta-clang:
  https://github.com/kraj/meta-clang/commit/0f8dc80ce0dcb74bcb745aa7169b2e04a0f3fba9

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>