### PR TITLE
kselftests-next: refresh net/Makefile patch for LDLIBS

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180416.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180416.patch
@@ -1,0 +1,75 @@
+From cee4a02aad2c77ab93d69cb3d8d533779e5aaab7 Mon Sep 17 00:00:00 2001
+From: Fathi Boudra <fathi.boudra@linaro.org>
+Date: Wed, 28 Jun 2017 20:08:57 +0300
+Subject: [PATCH 1/8] selftests: net: use LDLIBS instead of LDFLAGS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+reuseport_bpf_numa fails to build due to undefined reference errors:
+
+ aarch64-linaro-linux-gcc
+ --sysroot=/build/tmp-rpb-glibc/sysroots/hikey -Wall
+ -Wl,--no-as-needed -O2 -g -I../../../../usr/include/  -Wl,-O1
+ -Wl,--hash-style=gnu -Wl,--as-needed -lnuma  reuseport_bpf_numa.c
+ -o
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa
+ /tmp/ccfUuExT.o: In function `send_from_node':
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:138:
+ undefined reference to `numa_run_on_node'
+ /tmp/ccfUuExT.o: In function `main':
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:230:
+ undefined reference to `numa_available'
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:233:
+ undefined reference to `numa_max_node'
+
+It's GNU Make and linker specific.
+
+The default Makefile rule looks like:
+
+$(CC) $(CFLAGS) $(LDFLAGS) $@ $^ $(LDLIBS)
+
+When linking is done by gcc itself, no issue, but when it needs to be passed
+to proper ld, only LDLIBS follows and then ld cannot know what libs to link
+with.
+
+More detail:
+https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+
+LDFLAGS
+Extra flags to give to compilers when they are supposed to invoke the linker,
+‘ld’, such as -L. Libraries (-lfoo) should be added to the LDLIBS variable
+instead.
+
+LDLIBS
+Library flags or names given to compilers when they are supposed to invoke the
+linker, ‘ld’. LOADLIBES is a deprecated (but still supported) alternative to
+LDLIBS. Non-library linker flags, such as -L, should go in the LDFLAGS
+variable.
+
+https://lkml.org/lkml/2010/2/10/362
+
+tools/perf: libraries must come after objects
+
+Link order matters, use LDLIBS instead of LDFLAGS to properly link against
+libnuma.
+
+Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
+---
+ tools/testing/selftests/net/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/testing/selftests/net/Makefile b/tools/testing/selftests/net/Makefile
+index c3761c3..a89110d 100644
+--- a/tools/testing/selftests/net/Makefile
++++ b/tools/testing/selftests/net/Makefile
+@@ -14,5 +14,5 @@ TEST_GEN_PROGS += reuseport_dualstack reuseaddr_conflict
+ 
+ include ../lib.mk
+ 
+-$(OUTPUT)/reuseport_bpf_numa: LDFLAGS += -lnuma
++$(OUTPUT)/reuseport_bpf_numa: LDLIBS += -lnuma
+ $(OUTPUT)/tcp_mmap: LDFLAGS += -lpthread
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -11,7 +11,7 @@ SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
     file://0001-selftests-gpio-fix-build-error.patch \
     file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
-    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS.patch \
+    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180416.patch \
     file://0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "


### PR DESCRIPTION
Commit 192dc405f in linux-next/master added program tcp_mmap,
which required an updated patch for the LDFLAGS/LDLIBS
changes.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>