### PR TITLE
kselftests-mainline: upgrade to 4.16

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-mainline_4.16.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.16.bb
@@ -14,8 +14,8 @@ SRC_URI += "\
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 
-SRC_URI[md5sum] = "0d701ac1e2a67d47ce7127432df2c32b"
-SRC_URI[sha256sum] = "5a26478906d5005f4f809402e981518d2b8844949199f60c4b6e1f986ca2a769"
+SRC_URI[md5sum] = "1357fb4ee7c288fdeac5d4e0048f5c18"
+SRC_URI[sha256sum] = "63f6dc8e3c9f3a0273d5d6f4dca38a2413ca3a5f689329d05b750e4c87bb21b9"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>