### PR TITLE
Kselftests fixes wrt sysroot and headers

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -13,6 +13,9 @@ do_compile() {
     # Make sure to install the user space API used by some tests
     # but not properly declared as a build dependency
     ${MAKE} -C ${S} ARCH=${ARCH} headers_install
+
+    # Specifying sysroot may help Clang find appropriate headers
+    export CLANG="clang --sysroot ${STAGING_DIR_TARGET}"
     ${MAKE} ${KSELFTESTS_ARGS}
 }
 


### PR DESCRIPTION
Clang does not know much about sysroot, so help here by passing the --sysroot switch via the CLANG environment variable. Also, some headers are needed in order to build some kselftests (at least bpf), so better make that dependency explicit.