### PR TITLE
selftests: add uuidgen to RDEPENDS

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -34,6 +34,7 @@ FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc glibc-utils ncurses sudo"
 RDEPENDS_${PN} =+ "python3-argparse python3-datetime python3-json python3-pprint python3-subprocess"
+RDEPENDS_${PN} =+ "util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"
 RDEPENDS_${PN}_append_x86-64 = " cpupower"
 


### PR DESCRIPTION
Kselftests net/rtnetlink.sh fails due to uuidgen isn't installed into
the rootfs:
./rtnetlink.sh: line 280: uuidgen: command not found

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>