### PR TITLE
kselftests-next: rename Git repository to kernel-next

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 PV = "4.15+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel"
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel-next"
 # Patches inappropriate or not yet merged by upstream
 # Some patches may have been submitted to upstream
 SRC_URI += "\


### PR DESCRIPTION
It may happen that if a version is set for a kernel (not from linux-next), the fetcher will be unable to find the specified revision in the tree. Exempli gratia:

If `SRCREV_kernel` is set to `0f105cf4f60e5afdf2932fed7f05ce776ce14289` globally, (which is a fine kernel for torvalds/master, mainline), then this package would try to fetch the very same revision but from linux-next/master:
```
WARNING: kselftests-next-4.15+gitAUTOINC+0f105cf4f6-r0 do_fetch: Failed to fetch URL git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel, attempting MIRRORS if available
ERROR: kselftests-next-4.15+gitAUTOINC+0f105cf4f6-r0 do_fetch: Fetcher failure: Unable to find revision 0f105cf4f60e5afdf2932fed7f05ce776ce14289 in branch master even from upstream
ERROR: kselftests-next-4.15+gitAUTOINC+0f105cf4f6-r0 do_fetch: Fetcher failure for URL: 'git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel'. Unable to fetch URL from any source.
ERROR: kselftests-next-4.15+gitAUTOINC+0f105cf4f6-r0 do_fetch: Function failed: base_do_fetch
```

If we want to accommodate two different versions of the Linux kernel and kselftests (or rather different repositories) then we need to have this renamed here.