### PR TITLE
kselftests-mainline/-next: upgrade to 4.17

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-mainline_4.17.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.17.bb
@@ -14,8 +14,8 @@ SRC_URI += "\
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 
-SRC_URI[md5sum] = "1357fb4ee7c288fdeac5d4e0048f5c18"
-SRC_URI[sha256sum] = "63f6dc8e3c9f3a0273d5d6f4dca38a2413ca3a5f689329d05b750e4c87bb21b9"
+SRC_URI[md5sum] = "5bb13a03274b66b56c85b26682e407d7"
+SRC_URI[sha256sum] = "9faa1dd896eaea961dc6e886697c0b3301277102e5bc976b2758f9a62d3ccd13"
 
 S = "${WORKDIR}/linux-${PV}"
 

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Linux Kernel Selftests (linux-kselftest next)"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
-PV = "4.15+git${SRCPV}"
+PV = "4.17+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel-next"


### PR DESCRIPTION
Update PV of kselftests-mainline and in kselftests-next.