### PR TITLE
Add packagegroup-rpb-tests-weston.bb

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-weston.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Test apps that can be used in Weston Desktop"
+
+inherit packagegroup
+
+PROVIDES = "${PACKAGES}"
+PACKAGES = "\
+    packagegroup-rpb-tests-weston \
+    "
+RDEPENDS_packagegroup-rpb-tests-weston = "\
+    gst-validate \
+    "


### PR DESCRIPTION
packagegroup-rpb-tests-weston includes test apps which can be used
in Weston Desktop.
In order to run gst-validate test with MMWG OE Weston build, some packages are needed.
So, I created a packagesgroup to organize it.