### PR TITLE
lkft: Fixes and dependency

### DIFF
--- a/recipes-samples/images/rpb-console-image-lkft.bb
+++ b/recipes-samples/images/rpb-console-image-lkft.bb
@@ -4,6 +4,10 @@ SUMMARY = "Basic console image for LKFT"
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
+# Add 256 MB on X15; more than that might exceed the
+# userdata partition capacity.
+IMAGE_ROOTFS_EXTRA_SPACE_am57xx-evm = "262144"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     packagegroup-rpb-lkft \

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -8,6 +8,6 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kernel-selftests \
     kselftests-mainline \
     kselftests-next \
-    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+    ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     tzdata \
     "

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -9,4 +9,5 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-mainline \
     kselftests-next \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+    tzdata \
     "


### PR DESCRIPTION
Add missing dependency:
* `tzdata`

Fix architecture check in order to include numactl, and reduce the min. extra available space in the root file system from 1 GB to 256 MB, in order to fit into X15 userdata partition.