### PR TITLE
packagegroup-rpb-lkft: add haveged

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 # contains basic dependencies for LKFT
 RDEPENDS_packagegroup-rpb-lkft = "\
     git \
+    haveged \
     kernel-selftests \
     kselftests-mainline \
     kselftests-next \


### PR DESCRIPTION
A couple of bugs are related to lack of entropy, which can
be very easily solved by having haveged running.

HAVEGE algorithm explained here:
http://www.irisa.fr/caps/projects/hipsor/misc.php#exectime
regarding how randomness is obtained and about its
unpredictability. While rng-tools is the "preferred" method,
enough entropy might be very difficult in a headless
development board, where haveged would definitely be a great
addition.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>