### PR TITLE
[Sumo backport] rpb: disable multilib

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -26,7 +26,7 @@ def get_multilib_handler(d):
 
 # Use a weak include to avoid to produce an error when the file cannot be found.
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
-include ${@get_multilib_handler(d)}
+#include ${@get_multilib_handler(d)}
 
 GCCVERSION ?= "linaro-7.2"
 


### PR DESCRIPTION
Multilib creates more issues than is solves currently, e.g. LKFT runs into weird issues with headers. The original reason to enable it went away, so disable it.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>