### PR TITLE
kselftests-next: refresh net/gpio Makefile patches

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-gpio-fix-build-error-next-20180906.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-gpio-fix-build-error-next-20180906.patch
@@ -1,0 +1,58 @@
+From aa6ffd50aca05f7c3e56373c6137bba40183367b Mon Sep 17 00:00:00 2001
+From: Marcin Nowakowski <marcin.nowakowski@imgtec.com>
+Date: Fri, 23 Jun 2017 12:37:25 +0200
+Subject: [PATCH 2/6] selftests/gpio: fix build error
+
+While building selftests/gpio, gpio-utils from linux/tools/gpio as built
+in the process as well. However, the OUTPUT make variable usage in
+selftests breaks the build system in linux/tools/gpio resulting in its
+output files placed in the selftests folder (due to lack of trailing
+slash in the path, the files are placed directly in selftests):
+
+make -f linux/tools/build/Makefile.build dir=. obj=lsgpio
+make[3]: Entering directory '/mnt/ssd/MIPS/linux-next/tools/gpio'
+CC    linux/tools/testing/selftests/gpiolsgpio.o
+CC    linux/tools/testing/selftests/gpiogpio-utils.o
+LD    linux/tools/testing/selftests/gpiolsgpio-in.o
+
+This pollutes the selftests directory and, most importantly, makes it
+impossible for selftests/gpio to find the object file it's looking for
+to link the test:
+
+cc -O2 -g -std=gnu99 -Wall -I../../../../usr/include/
+gpio-mockup-chardev.c ../../../gpio/gpio-utils.o
+../../../../usr/include/linux/gpio.h  -lmount -I/usr/include/libmount -o
+gpio-mockup-chardev
+gcc: error: ../../../gpio/gpio-utils.o: No such file or directory
+
+Fix this by clearing the OUTPUT variable when invoking linux/tools/gpio
+make to ensure it's built where expected.
+
+Note, that this solution is not ideal as the output is placed in
+linux/tools/gpio rather than a location relative to OUTPUT, but this at
+least ensures the build succeeds.
+Due to differences and complexities of selftests and linux/tools build
+systems, it's not trivial to ensure linux/tools get built properly when
+invoked recursively from selftests build and this is left as a future
+task to resolve properly.
+
+Fixes: a8ba798bc8ec ('selftests: enable O and KBUILD_OUTPUT')
+
+Signed-off-by: Marcin Nowakowski <marcin.nowakowski@imgtec.com>
+---
+ tools/testing/selftests/gpio/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/testing/selftests/gpio/Makefile b/tools/testing/selftests/gpio/Makefile
+index 4665cdb..b1934c8 100644
+--- a/tools/testing/selftests/gpio/Makefile
++++ b/tools/testing/selftests/gpio/Makefile
+@@ -25,4 +25,4 @@ $(BINARIES):| khdr
+ $(BINARIES): ../../../gpio/gpio-utils.o
+ 
+ ../../../gpio/gpio-utils.o:
+-	make ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C ../../../gpio
++	make ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C ../../../gpio OUTPUT=
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/files/0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20180906.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20180906.patch
@@ -1,0 +1,36 @@
+From d69d0f39bcab849c1c5fd0ae7675ddeae8c7acda Mon Sep 17 00:00:00 2001
+From: Fathi Boudra <fathi.boudra@linaro.org>
+Date: Thu, 29 Jun 2017 09:53:14 +0300
+Subject: [PATCH 3/6] selftests: gpio: use pkg-config to determine libmount
+ CFLAGS/LDLIBS
+
+Fix hardcoded and misplaced libmount headers. Use pkg-config instead to
+figure out CFLAGS/LDLIBS, fixing also their value for cross-compilation.
+
+If pkg-config isn't installed, it gives an error (command not found) and
+gpio test will fail to build because it won't be able to find the headers
+or link to libmount library.
+
+Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
+---
+ tools/testing/selftests/gpio/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/testing/selftests/gpio/Makefile b/tools/testing/selftests/gpio/Makefile
+index b1934c8..3225f78 100644
+--- a/tools/testing/selftests/gpio/Makefile
++++ b/tools/testing/selftests/gpio/Makefile
+@@ -18,8 +18,8 @@ override define CLEAN
+ 	$(RM) -r $(EXTRA_DIRS)
+ endef
+ 
+-CFLAGS += -O2 -g -std=gnu99 -Wall -I../../../../usr/include/
+-LDLIBS += -lmount -I/usr/include/libmount
++CFLAGS += -O2 -g -std=gnu99 -Wall -I../../../../usr/include/ $(shell pkg-config --cflags mount)
++LDLIBS += $(shell pkg-config --libs mount)
+ 
+ $(BINARIES):| khdr
+ $(BINARIES): ../../../gpio/gpio-utils.o
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/files/0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch
@@ -1,0 +1,76 @@
+From 181aa07d160c52d6e5983f199359a5853ab9d7a5 Mon Sep 17 00:00:00 2001
+From: Fathi Boudra <fathi.boudra@linaro.org>
+Date: Wed, 28 Jun 2017 20:08:57 +0300
+Subject: [PATCH 4/6] selftests: net: use LDLIBS instead of LDFLAGS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+reuseport_bpf_numa fails to build due to undefined reference errors:
+
+ aarch64-linaro-linux-gcc
+ --sysroot=/build/tmp-rpb-glibc/sysroots/hikey -Wall
+ -Wl,--no-as-needed -O2 -g -I../../../../usr/include/  -Wl,-O1
+ -Wl,--hash-style=gnu -Wl,--as-needed -lnuma  reuseport_bpf_numa.c
+ -o
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa
+ /tmp/ccfUuExT.o: In function `send_from_node':
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:138:
+ undefined reference to `numa_run_on_node'
+ /tmp/ccfUuExT.o: In function `main':
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:230:
+ undefined reference to `numa_available'
+ /build/tmp-rpb-glibc/work/hikey-linaro-linux/kselftests/4.12-r0/linux-4.12-rc7/tools/testing/selftests/net/reuseport_bpf_numa.c:233:
+ undefined reference to `numa_max_node'
+
+It's GNU Make and linker specific.
+
+The default Makefile rule looks like:
+
+$(CC) $(CFLAGS) $(LDFLAGS) $@ $^ $(LDLIBS)
+
+When linking is done by gcc itself, no issue, but when it needs to be passed
+to proper ld, only LDLIBS follows and then ld cannot know what libs to link
+with.
+
+More detail:
+https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+
+LDFLAGS
+Extra flags to give to compilers when they are supposed to invoke the linker,
+‘ld’, such as -L. Libraries (-lfoo) should be added to the LDLIBS variable
+instead.
+
+LDLIBS
+Library flags or names given to compilers when they are supposed to invoke the
+linker, ‘ld’. LOADLIBES is a deprecated (but still supported) alternative to
+LDLIBS. Non-library linker flags, such as -L, should go in the LDFLAGS
+variable.
+
+https://lkml.org/lkml/2010/2/10/362
+
+tools/perf: libraries must come after objects
+
+Link order matters, use LDLIBS instead of LDFLAGS to properly link against
+libnuma.
+
+Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
+---
+ tools/testing/selftests/net/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/testing/selftests/net/Makefile b/tools/testing/selftests/net/Makefile
+index 256d82d..83c9468 100644
+--- a/tools/testing/selftests/net/Makefile
++++ b/tools/testing/selftests/net/Makefile
+@@ -18,6 +18,6 @@ TEST_GEN_PROGS += reuseport_dualstack reuseaddr_conflict tls
+ KSFT_KHDR_INSTALL := 1
+ include ../lib.mk
+ 
+-$(OUTPUT)/reuseport_bpf_numa: LDFLAGS += -lnuma
++$(OUTPUT)/reuseport_bpf_numa: LDLIBS += -lnuma
+ $(OUTPUT)/tcp_mmap: LDFLAGS += -lpthread
+ $(OUTPUT)/tcp_inq: LDFLAGS += -lpthread
+-- 
+2.7.4
+

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -9,9 +9,9 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;pro
 # Some patches may have been submitted to upstream
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
-    file://0001-selftests-gpio-fix-build-error.patch \
-    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
-    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180416.patch \
+    file://0001-selftests-gpio-fix-build-error-next-20180906.patch \
+    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20180906.patch \
+    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch \
     file://0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "


### PR DESCRIPTION
As of next-20180906, a few Makefiles were slightly modified,
not much but enough to spoil the clean application of the
patches that we need.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>