### PR TITLE
ltp: Remove license for pounder21, which has been removed

### DIFF
--- a/recipes-overlayed/ltp/ltp_git.bb
+++ b/recipes-overlayed/ltp/ltp_git.bb
@@ -11,7 +11,6 @@ LIC_FILES_CHKSUM = "\
     file://testcases/kernel/hotplug/cpu_hotplug/COPYING;md5=e04a2e542b2b8629bf9cd2ba29b0fe41 \
     file://testcases/open_posix_testsuite/COPYING;md5=48b1c5ec633e3e30ec2cf884ae699947 \
     file://testcases/realtime/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
-    file://tools/pounder21/COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
     file://utils/benchmark/kernbench-0.42/COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
     file://utils/ffsb-6.0-rc2/COPYING;md5=c46082167a314d785d012a244748d803 \
 "


### PR DESCRIPTION
As of commit 54d3e8696798, LTP has removed pounder21 stating
that "[i]t's is obsolete, not being built", so the recipe
fails trying to locate its license fail like this:
  ERROR: ltp-20180118+gitAUTOINC+7599ff232b-r0 do_populate_lic: QA Issue: ltp:
  LIC_FILES_CHKSUM points to an invalid file: /oe/build/tmp-rpb-glibc/work
  /core2-32-linaro-linux/ltp/20180118+gitAUTOINC+7599ff232b-r0/git/tools
  /pounder21/COPYING [license-checksum]

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>