### PR TITLE
conf/layer.conf: Add LAYERSERIES_COMPAT set to thud

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,3 +7,5 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 BBFILE_COLLECTIONS += "meta-rpb"
 BBFILE_PATTERN_meta-rpb := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpb = "8"
+
+LAYERSERIES_COMPAT_meta-rpb = "thud"


### PR DESCRIPTION
Since sumo the LAYERSERIES_COMPAT flag is needed to ensure
layer compatibility so set to thud because will be the next
stable version now master.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>