### PR TITLE
recipes-samples/packagegroups: Remove chromium in RPB packagegroups

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -7,7 +7,6 @@ PACKAGES = "\
     packagegroup-rpb-tests-x11 \
     "
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
-    chromium-x11-chromedriver \
     gst-validate \
     piglit \
     xserver-xorg-xvfb \

--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -7,8 +7,6 @@ REQUIRED_DISTRO_FEATURES = "wayland"
 
 SUMMARY_packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS_packagegroup-rpb-weston = "\
-    chromium-ozone-wayland \
-    chromium-ozone-wayland-chromedriver \
     clutter-1.0-examples \
     ffmpeg \
     gps-utils \

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -5,7 +5,6 @@ REQUIRED_DISTRO_FEATURES = "x11"
 
 SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
 RDEPENDS_packagegroup-rpb-x11 = "\
-    chromium-x11 \
     ffmpeg \
     glmark2 \
     gps-utils \


### PR DESCRIPTION
Currently chromium build is failing on master, We maintain our own
recipe for chromium, remove it for now have succesful builds in desktop
and weston images.

https://ci.linaro.org/job/96boards-reference-platform-openembedded-master/763/DISTRO=rpb,MACHINE=dragonboard-820c,label=docker-stretch-amd64/console
https://ci.linaro.org/job/96boards-reference-platform-openembedded-master/763/DISTRO=rpb-wayland,MACHINE=dragonboard-820c,label=docker-stretch-amd64/console

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>