### PR TITLE
kselftests-next: Refresh gpio Makefile patch

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20181008.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20181008.patch
@@ -1,0 +1,35 @@
+From ff09f4ad44a758367c55e0634b47c0743abafa12 Mon Sep 17 00:00:00 2001
+From: Fathi Boudra <fathi.boudra@linaro.org>
+Date: Thu, 29 Jun 2017 09:53:14 +0300
+Subject: [PATCH] selftests: gpio: use pkg-config to determine libmount
+ CFLAGS/LDLIBS
+
+Fix hardcoded and misplaced libmount headers. Use pkg-config instead to
+figure out CFLAGS/LDLIBS, fixing also their value for cross-compilation.
+
+If pkg-config isn't installed, it gives an error (command not found) and
+gpio test will fail to build because it won't be able to find the headers
+or link to libmount library.
+
+Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
+---
+ tools/testing/selftests/gpio/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/testing/selftests/gpio/Makefile b/tools/testing/selftests/gpio/Makefile
+index 46648427d537..7272f1931ccb 100644
+--- a/tools/testing/selftests/gpio/Makefile
++++ b/tools/testing/selftests/gpio/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ 
+-CFLAGS += -O2 -g -std=gnu99 -Wall -I../../../../usr/include/
+-LDLIBS += -lmount -I/usr/include/libmount
++CFLAGS += -O2 -g -std=gnu99 -Wall -I../../../../usr/include/ $(shell pkg-config --cflags mount)
++LDLIBS += $(shell pkg-config --libs mount)
+ 
+ TEST_PROGS := gpio-mockup.sh
+ TEST_FILES := gpio-mockup-sysfs.sh
+-- 
+2.17.1
+

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -9,8 +9,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;pro
 # Some patches may have been submitted to upstream
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
-    file://0001-selftests-gpio-fix-build-error-next-20180906.patch \
-    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20180906.patch \
+    file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-next-20181008.patch \
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch \
     file://0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \


### PR DESCRIPTION
As of next-20181008, the GPIO Makefile was updated, thus
requiring only one patch, which had to be refreshed:
* 0001-selftests-gpio-fix-build-error: not needed anymore
* 0001-selftests-gpio-use-pkg-config-to-determine-libmount: updated

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>