### PR TITLE
kselftests: Add iputils-ping6 to RDEPENDS

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -32,7 +32,7 @@ FILES_${PN} = "${INSTALL_PATH}"
 FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc glibc-utils ncurses sudo"
+RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping6 glibc-utils ncurses sudo"
 RDEPENDS_${PN} =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${PN} =+ "util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"


### PR DESCRIPTION
ping6 is used by net's pmtu.sh test:
  https://bugs.linaro.org/show_bug.cgi?id=3830

Busybox' ping6 is not good for this test as it doesn't
implement the -i parameter.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>