### PR TITLE
[donotmergeyet] kselftests-mainline: Upgrade to 4.19

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-mainline_4.19.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_4.19.bb
@@ -7,15 +7,15 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz"
 # Some patches may have been submitted to upstream
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
-    file://0001-selftests-gpio-fix-build-error.patch \
+    file://0001-selftests-gpio-fix-build-error-next-20180906.patch \
     file://0001-selftests-gpio-use-pkg-config-to-determine-libmount-.patch \
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180416.patch \
     file://0002-selftests-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 
-SRC_URI[md5sum] = "bee5fe53ee1c3142b8f0c12c0d3348f9"
-SRC_URI[sha256sum] = "19d8bcf49ef530cd4e364a45b4a22fa70714b70349c8100e7308488e26f1eaf1"
+SRC_URI[md5sum] = "740a90cf810c2105df8ee12e5d0bb900"
+SRC_URI[sha256sum] = "0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
Update one patch, from:
  0001-selftests-gpio-fix-build-error.patch
to:
  0001-selftests-gpio-fix-build-error-next-20180906.patch
which we already had in place for kselftests-next.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>