### PR TITLE
packagegroups/packagegroup-rpb-tests: enable s-suite

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -42,6 +42,7 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     cpupower \
     libhugetlbfs-tests \
     ltp \
+    s-suite \
     stress-ng \
     ptest-runner \
     "


### PR DESCRIPTION
Enable s-suite, thats a storage I/O benchmark test suite.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>