### PR TITLE
[Do not merge][RFC] lkft-metadata bbclass: restore variable tracking and hashing

### DIFF
--- a/classes/lkft-metadata.bbclass
+++ b/classes/lkft-metadata.bbclass
@@ -40,8 +40,9 @@ addhandler lkftmetadata_eventhandler
 lkftmetadata_eventhandler[eventmask] = "bb.event.BuildCompleted bb.event.BuildStarted"
 
 do_fetch[postfuncs] += "write_srcuri"
-do_fetch[vardepsexclude] += "write_srcuri"
+#do_fetch[vardepsexclude] += "write_srcuri"
 python write_srcuri() {
+    bb.note("Gathering lkftmetadata")
     import re
     pkghistdir = d.getVar('LKFTMETADATA_DIR_PACKAGE', True)
     if not os.path.exists(pkghistdir):


### PR DESCRIPTION
This class copied buildhistory.bbclass which excludes itself from variable tracking to avoid rebuilds after enabling the class. For LKFT we *do* want rebuilds, so remove the exclusing parameter.

Also add a bb.note to note when the class starts doing its thing.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>