### PR TITLE
Add procotol=http to ltp SRC_URI

### DIFF
--- a/recipes-overlayed/ltp/ltp_git.bb
+++ b/recipes-overlayed/ltp/ltp_git.bb
@@ -26,7 +26,7 @@ PV = "20180118+git${SRCPV}"
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI = "git://github.com/linux-test-project/ltp.git"
+SRC_URI = "git://github.com/linux-test-project/ltp.git;protocol=http"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Use HTTP rather than git protocol so that things Just Work t.m. even for people operating behind corporate proxies that only allow outbound HTTP(S) connections.