### PR TITLE
packagegroup-rpb-tests: add v4l-utils package for v4l2-compliance

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -24,4 +24,5 @@ RDEPENDS_packagegroup-rpb = "\
     python-modules \
     rsync \
     sshfs-fuse \
+    v4l-utils \
     "


### PR DESCRIPTION
The v4l2-compliance tool is used to test video4linux devices, either
video, vbi, radio or swradio, both input and output. It attempts to
test almost all aspects of a V4L2 device and it covers almost all V4L2
ioctls. It has very good support for video capture and output, VBI
capture and output and (software) radio tuning and transmitting.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>