### PR TITLE
arm-defaults.inc: don't enforce thumb for armv7a machines

### DIFF
--- a/conf/distro/include/arm-defaults.inc
+++ b/conf/distro/include/arm-defaults.inc
@@ -11,7 +11,10 @@
 def arm_tune_handler(d):
     features = d.getVar('TUNE_FEATURES', True).split()
     if 'armv7a' in features:
-        tune = 'armv7athf'
+        if 'thumb' in features:
+            tune = 'armv7athf'
+        else:
+            tune = 'armv7ahf'
         if 'bigendian' in features:
             tune += 'b'
         if 'vfpv3' in features:


### PR DESCRIPTION
For armv7a arm_tune_handler() enforces not only hard-float, but
also thumb. But the comment for this function doesn't say that
RPB must use thumb, so the current implementation is more restrictive
than it should be.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>