### PR TITLE
packagegroup-rpb: make it possible to override optee packages names

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -4,6 +4,12 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 inherit packagegroup
 
+# There exist BSP layers which use custom names for their optee recipes.
+# E.g. optee-client-qoriq from meta-freescale vs optee-client.
+# The variable below can be overrided to make it possible to use
+# such BSP layers with meta-rpb.
+OPTEE_PACKAGES ?= "optee-test optee-client"
+
 # contains basic dependencies, that can work without graphics/display
 RDEPENDS_packagegroup-rpb = "\
     96boards-tools \
@@ -19,7 +25,7 @@ RDEPENDS_packagegroup-rpb = "\
     networkmanager \
     networkmanager-nmtui \
     openssh-sftp-server \
-    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "optee-test optee-client", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "optee", d.getVar("OPTEE_PACKAGES", True), "", d)} \
     python-misc \
     python-modules \
     rsync \


### PR DESCRIPTION
There exist BSP layers which provide their own variants of optee, and
the package names are different. To account for that, introduce new
OPTEE_PACKAGES variable, initialize it to "optee-test  optee-client",
and make it overridable.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>