### PR TITLE
rpb.inc: Switch to OE-core gcc 8

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,7 +28,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "linaro-7.2"
+#GCCVERSION ?= "linaro-7.2"
 
 DISTRO_FEATURES_append = " opengl pam systemd ptest"
 DISTRO_FEATURES_remove = "3g sysvinit"


### PR DESCRIPTION
Gcc 7.x is outdated nowadays and the Arm version of gcc 8.x can't build go, so use the upstream OE-core version

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>