### PR TITLE
gstreamer1.0-libav_%.bbappend: disable thumb for armv7a

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,0 +1,2 @@
+# Disable thumb
+ARM_INSTRUCTION_SET_armv7a = "arm"


### PR DESCRIPTION
On am5728-evm board, if thumb is enabled, an attempt to play an h264-encoded
video fails with:
"illegal instruction in libgstlibav.so, ff_h264_idct_dc_add_neon()”

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>