### PR TITLE
Support of sota on THUD branch

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -52,6 +52,9 @@ IMAGE_FSTYPES_remove = "tar.gz"
 IMAGE_FSTYPES_append_omap-a15 = " ext4.gz"
 IMAGE_FSTYPES_append_beaglebone = " ext4.gz"
 
+# meta-updater is unsafe to include, it fails to parse without setting this:
+OSTREE_INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'ext4.gz.u-boot', 'ext4.gz')}"
+
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"

--- a/conf/distro/rpb-sota.conf
+++ b/conf/distro/rpb-sota.conf
@@ -1,0 +1,8 @@
+require conf/distro/include/rpb.inc
+require conf/distro/sota.conf.inc
+
+DISTRO_NAME = "Reference-Platform-Build-SOTA"
+
+OSTREE_OSNAME = "oe-rpb"
+OSTREE_INITRAMFS_FSTYPES = "cpio.gz"
+IMAGE_BOOT_FILES_sota = " ${KERNEL_IMAGETYPE}"


### PR DESCRIPTION
Add support of sota on Thud branch:
- report of work made on Sumo branch on Thud branch.
Cherry-pick of commit from Sumo branch: 
3fc09e6 Add sota distro variant
7ce19a6 rpb: declare OSTREE_INITRAMFS_FSTYPES to stop parse failures with meta-updater included
