### PR TITLE
arm-defaults.inc: also fix cortexa* tune files

### DIFF
--- a/conf/distro/include/arm-defaults.inc
+++ b/conf/distro/include/arm-defaults.inc
@@ -10,21 +10,23 @@
 
 def arm_tune_handler(d):
     features = d.getVar('TUNE_FEATURES', True).split()
-    if 'armv7a' in features:
+    if 'armv7a' in features or 'armv7ve' in features:
         tune = 'armv7athf'
         if 'bigendian' in features:
             tune += 'b'
-        if 'vfpv3' in features:
-            tune += '-vfpv3'
-        if 'vfpv3d16' in features:
-            tune += '-vfpv3d16'
         if 'neon' in features:
             tune += '-neon'
-        if 'vfpv4' in features:
-            tune += '-vfpv4'
+    # cortexa* tune files only list 'arm' in features instead of 'armv7*', so
+    # try matching it on neon
+    elif 'arm' in features and 'neon' in features:
+        tune = 'armv7athf'
+        if 'bigendian' in features:
+            tune += 'b'
+        if 'neon' in features:
+            tune += '-neon'
     else:
         tune = d.getVar('DEFAULTTUNE', True)
     return tune
 
-# Should use a distro override 
+# Should use a distro override
 DEFAULTTUNE := "${@arm_tune_handler(d)}"


### PR DESCRIPTION
Without this meta-browser will break parsing because it wants -march in
TUNE_CCARGS, but tune-cortexa*.inc only have -mtune.

Also merge in fixes from Angstrom to further collapse tunings to a
common vfp one.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>