### PR TITLE
distro: Correct version for Sumo

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -1,4 +1,4 @@
-DISTRO_VERSION = "2.4+linaro"
+DISTRO_VERSION = "2.5+linaro"
 
 # These default to 'oecore' and 'nodistro'
 SDK_NAME_PREFIX = "${DISTRO}"


### PR DESCRIPTION
The correct version for Sumo is 2.5.