### PR TITLE
Switch to oe-core toolchain

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,7 +28,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "linaro-7.2"
+#GCCVERSION ?= "linaro-7.2"
 
 DISTRO_FEATURES_append = " opengl pam systemd ptest"
 DISTRO_FEATURES_remove = "3g sysvinit"


### PR DESCRIPTION
Linaro toolchain is unable to build Chromium v72 in meta-browser

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>