### PR TITLE
rpb.inc: Switch to ARM gcc 8.2 toolchain

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,7 +28,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "linaro-7.2"
+GCCVERSION ?= "arm-8.2"
 
 DISTRO_FEATURES_append = " opengl pam systemd ptest"
 DISTRO_FEATURES_remove = "3g sysvinit"


### PR DESCRIPTION
ARM gcc 8.2 recipe is now merged on meta-linaro repository. 

Signed-off-by: Vishal Bhoj <vishal.bhoj@linaro.org>