### PR TITLE
conf/layer.conf: add warrior to compatible release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "meta-rpb"
 BBFILE_PATTERN_meta-rpb := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpb = "8"
 
-LAYERSERIES_COMPAT_meta-rpb = "thud"
+LAYERSERIES_COMPAT_meta-rpb = "thud warrior"


### PR DESCRIPTION
Fix pre-merge CI failure:
ERROR: Layer meta-rpb is not compatible with the core layer which only
supports these series: warrior (layer is compatible with thud)

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>