### PR TITLE
Check layer

### DIFF
--- a/conf/distro/rpb-eglfs.conf
+++ b/conf/distro/rpb-eglfs.conf
@@ -5,3 +5,4 @@ DISTRO_NAME = "Reference-Platform-Build-EGLFS"
 PACKAGECONFIG_append_pn-qtbase = " eglfs kms gbm"
 
 DISTRO_FEATURES_remove = "wayland x11"
+DISTROOVERRIDES = "rpb:rpb-eglfs"

--- a/conf/distro/rpb-wayland.conf
+++ b/conf/distro/rpb-wayland.conf
@@ -7,3 +7,4 @@ DISTRO_FEATURES_remove = "x11"
 
 PREFERRED_PROVIDER_libgbm_omap-a15 = "libgbm"
 PREFERRED_PROVIDER_libgbm-dev_omap-a15 = "libgbm-dev"
+DISTROOVERRIDES = "rpb:rpb-wayland"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,6 @@ BBFILE_PATTERN_meta-rpb := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpb = "8"
 
 LAYERSERIES_COMPAT_meta-rpb = "warrior"
+
+LAYERDEPENDS_meta-rpb = "openembedded-layer meta-python networking-layer \
+                         filesystems-layer virtualization-layer meta-96boards"

--- a/recipes-overlayed/busybox/busybox_1.%.bbappend
+++ b/recipes-overlayed/busybox/busybox_1.%.bbappend
@@ -1,3 +1,2 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://enable-setsid-tty.cfg"
-SRC_URI += "file://enable-install.cfg"
+SRC_URI_append_rpb = " file://enable-setsid-tty.cfg file://enable-install.cfg"


### PR DESCRIPTION
With these changes I was able to run yocto-check-layer to pass compatibility tests. with the caveat that I needed to remove references to docker and meta-virtualization which are failing compliance.