### PR TITLE
packagegroup-rpb: add some useful dev utilities

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -17,9 +17,12 @@ RDEPENDS_packagegroup-rpb = "\
     coreutils \
     cpufrequtils \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "docker", d)} \
+    file \
     gptfdisk \
     hostapd \
     htop \
+    ldd \
+    lsof \
     iptables \
     kernel-modules \
     networkmanager \
@@ -30,5 +33,6 @@ RDEPENDS_packagegroup-rpb = "\
     python-modules \
     rsync \
     sshfs-fuse \
+    strace \
     v4l-utils \
     "


### PR DESCRIPTION
When things don't work, strace, ldd, file are very
useful to figure out what might be happening.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>