### PR TITLE
packagegroup-rpb-tests: update to python3 packages

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -14,18 +14,7 @@ PACKAGES = "\
 RDEPENDS_packagegroup-rpb-tests = "\
     packagegroup-core-buildessential \
     packagegroup-rpb-tests-console \    
-    packagegroup-rpb-tests-python \
     packagegroup-rpb-tests-python3 \
-    "
-
-SUMMARY_packagegroup-rpb-tests-python = "Python support for running tests"
-RDEPENDS_packagegroup-rpb-tests-python = "\
-    python \
-    python-misc \
-    python-modules \
-    python-pexpect \
-    python-pip \
-    python-pyyaml \
     "
 
 SUMMARY_packagegroup-rpb-tests-python3 = "Python3 support for running tests"
@@ -33,6 +22,9 @@ RDEPENDS_packagegroup-rpb-tests-python3 = "\
     python3 \
     python3-misc \
     python3-modules \
+    python3-pexpect \
+    python3-pip \
+    python3-pyyaml \
     "
 
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -30,8 +30,8 @@ RDEPENDS_packagegroup-rpb = "\
     networkmanager-nmtui \
     openssh-sftp-server \
     ${@bb.utils.contains("MACHINE_FEATURES", "optee", d.getVar("OPTEE_PACKAGES", True), "", d)} \
-    python-misc \
-    python-modules \
+    python3-misc \
+    python3-modules \
     rsync \
     sshfs-fuse \
     strace \


### PR DESCRIPTION
python2 is EOL, update to python3.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>