### PR TITLE
recipes-samples: Remove python from RPB packagegroups

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -6,7 +6,6 @@ PROVIDES = "${PACKAGES}"
 PACKAGES = "\
     packagegroup-rpb-tests \
     packagegroup-rpb-tests-console \
-    packagegroup-rpb-tests-python \
     packagegroup-rpb-tests-python3 \
     "
 
@@ -14,18 +13,7 @@ PACKAGES = "\
 RDEPENDS_packagegroup-rpb-tests = "\
     packagegroup-core-buildessential \
     packagegroup-rpb-tests-console \    
-    packagegroup-rpb-tests-python \
     packagegroup-rpb-tests-python3 \
-    "
-
-SUMMARY_packagegroup-rpb-tests-python = "Python support for running tests"
-RDEPENDS_packagegroup-rpb-tests-python = "\
-    python \
-    python-misc \
-    python-modules \
-    python-pexpect \
-    python-pip \
-    python-pyyaml \
     "
 
 SUMMARY_packagegroup-rpb-tests-python3 = "Python3 support for running tests"

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -30,8 +30,8 @@ RDEPENDS_packagegroup-rpb = "\
     networkmanager-nmtui \
     openssh-sftp-server \
     ${@bb.utils.contains("MACHINE_FEATURES", "optee", d.getVar("OPTEE_PACKAGES", True), "", d)} \
-    python-misc \
-    python-modules \
+    python3-misc \
+    python3-modules \
     rsync \
     sshfs-fuse \
     strace \


### PR DESCRIPTION
Python 2.x was removed from OE-Core master due to EOL so remove python
related packages and change to Python 3.x.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>