### PR TITLE
packagegroup-rpb-tests: add net-snmp

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -34,6 +34,7 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     git \
     libhugetlbfs-tests \
     ltp \
+    net-snmp \
     s-suite \
     stress-ng \
     ptest-runner \


### PR DESCRIPTION
net-snmp is needed in igt Chamelium test for sending command to PDU
to power cycle Chamelium if it is unreachable.

Signed-off-by: Arthur <arthur.she@linaro.org>