### PR TITLE
recipes-overlayed: Add igt-gpu-tools append to enable Chamelium

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -38,6 +38,7 @@ PACKAGECONFIG_append_pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG_remove_pn-gpsd = "qt"
 PACKAGECONFIG_append_pn-gstreamer1.0-plugins-bad = " kms"
 PACKAGECONFIG_append_pn-ffmpeg = " sdl2"
+PACKAGECONFIG_append_pn-igt-gpu-tools = " chamelium"
 
 PREFERRED_PROVIDER_iasl-native = "acpica-native"
 PREFERRED_PROVIDER_iasl = "acpica"


### PR DESCRIPTION
The igt-gpu-tools recipe has been merged to OE-core [1],
however, the Chamelium support is disabled by default [2].

This bbappend will enable Chamelium support.

[1] http://layers.openembedded.org/layerindex/recipe/132395/
[2] https://lists.openembedded.org/g/openembedded-core/message/139726?p=,,,20,0,0,0::relevance,,chamelium,20,2,0,74985512

Signed-off-by: Arthur She <arthur.she@linaro.org>