### PR TITLE
packagegroup-rpb-tests: add igt-gpu-tools-tests

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,6 +32,7 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-speakertest \
     cpupower \
     git \
+    igt-gpu-tools-tests \
     libhugetlbfs-tests \
     ltp \
     net-snmp \


### PR DESCRIPTION
The igt-gpu-tools recipe has been merged to OE-core [1].
We'd like to have it be included in packagegroup-rpb-tests.

[1] https://git.openembedded.org/openembedded-core/tree/meta/recipes-graphics/igt-gpu-tools?id=d98e9b3612ab2c03503843cb3ea77bec7811a1d4

Signed-off-by: Arthur She <arthur.she@linaro.org>