### PR TITLE
recipes-samples: Add igt-gpu-tools-tests and net-snmp to packagegroup…

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,8 +32,10 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-speakertest \
     cpupower \
     git \
+    igt-gpu-tools-tests \
     libhugetlbfs-tests \
     ltp \
+    net-snmp \
     s-suite \
     stress-ng \
     ptest-runner \


### PR DESCRIPTION
…-rpb-tests

To enable igt Chamelium test, we need these packages.

Signed-off-by: Arthur She <arthur.she@linaro.org>