### PR TITLE
packagegroup-rpb-tests-x11: Add opengl-es-cts, parallel-deqp-runner

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -8,6 +8,8 @@ PACKAGES = "\
     "
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
     gst-validate \
+    opengl-es-cts \
+    parallel-deqp-runner \
     piglit \
     xserver-xorg-xvfb \
     "


### PR DESCRIPTION
To test freedreno graphics with deqp.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>