### PR TITLE
packagegroup-rpb-tests: add libdrm-tests and libgpiod-tools packages

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -34,6 +34,8 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     git \
     i2c-tools \
     igt-gpu-tools-tests \
+    libdrm-tests \
+    libgpiod-tools \
     libhugetlbfs-tests \
     ltp \
     net-snmp \


### PR DESCRIPTION
Enable two additional packages to assist in testing the hardware.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>