### PR TITLE
packagegroup-rpb-tests: disable igt-gpu-tools on musl

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -44,3 +44,4 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     ptest-runner \
     usbutils \
     "
+RDEPENDS_packagegroup-rpb-tests-console_remove_libc-musl = "igt-gpu-tools-tests"


### PR DESCRIPTION
igt-gpu-tools is not compatible with musl, disable corresponding dependency.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>