### PR TITLE
recipes-samples: Update gst-validate -> gst-devtools on pkggroups

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-weston.bb
@@ -7,5 +7,5 @@ PACKAGES = "\
     packagegroup-rpb-tests-weston \
     "
 RDEPENDS_packagegroup-rpb-tests-weston = "\
-    gst-validate \
+    gst-devtools \
     "

--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -7,7 +7,7 @@ PACKAGES = "\
     packagegroup-rpb-tests-x11 \
     "
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
-    gst-validate \
+    gst-devtools \
     opengl-es-cts \
     parallel-deqp-runner \
     piglit \


### PR DESCRIPTION
The gst-validate was deprecated now at gst-devtools see,

https://git.openembedded.org/openembedded-core/commit/?id=4af4c8d56da67545d2e5e1e2242ff6878b909e44

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>