### PR TITLE
packagegroup-rpb-x11: enable standard X11 programs

### DIFF
--- a/recipes-samples/images/rpb-desktop-image.bb
+++ b/recipes-samples/images/rpb-desktop-image.bb
@@ -12,6 +12,7 @@ SYSTEMD_DEFAULT_TARGET = "graphical.target"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-x11 \
+    packagegroup-rpb-x11-utils \
 "
 
 EXTRA_USERS_PARAMS += "\

--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -11,5 +11,9 @@ RDEPENDS_packagegroup-rpb-tests-x11 = "\
     opengl-es-cts \
     parallel-deqp-runner \
     piglit \
+    x11perf \
+    xdpyinfo \
+    xlsatoms \
+    xlsclients \
     xserver-xorg-xvfb \
     "

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -3,8 +3,10 @@ SUMMARY = "Organize packages to avoid duplication across all images (with X11)"
 inherit packagegroup features_check
 REQUIRED_DISTRO_FEATURES = "x11"
 
-SUMMARY_packagegroup-rpb-x11 = "Apps that can be used in X11 Desktop"
-RDEPENDS_packagegroup-rpb-x11 = "\
+PACKAGES += "${PN}-utils"
+
+SUMMARY_${PN} = "Apps that can be used in X11 Desktop"
+RDEPENDS_${PN} = "\
     96boards-artwork \
     feh-autostart \
     ffmpeg \
@@ -24,3 +26,21 @@ RDEPENDS_packagegroup-rpb-x11 = "\
     xf86-video-modesetting \
     xterm \
     "
+
+SUMMARY_${PN}-utils = "Additional utils that can be used in X11 Desktop"
+RDEPENDS_${PN}-utils = "\
+    iceauth \
+    sessreg \
+    setxkbmap \
+    xauth \
+    xclock \
+    xgamma \
+    xlsfonts \
+    xmag \
+    xmessage \
+    xrandr \
+    xrdb \
+    xrefresh \
+    xsetmode \
+    xsetroot \
+"


### PR DESCRIPTION
Enable several standard X11 programs usually found in most systems.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>