### PR TITLE
feh: make feh-autostart depend on feh

### DIFF
--- a/recipes-overlayed/feh/feh_%.bbappend
+++ b/recipes-overlayed/feh/feh_%.bbappend
@@ -11,6 +11,7 @@ do_install_append() {
 }
 
 PACKAGE_BEFORE_PN += "${PN}-autostart"
+RDEPENDS_${PN}-autostart += "${PN}"
 FILES_${PN}-autostart += " \
     ${sysconfdir}/xdg/autostart \
     ${bindir}/fehbg \


### PR DESCRIPTION
feh-autostart uses feh to set background, so add explicit dependency on
it.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>