### PR TITLE
packagegroup-rpb-tests-x11: add libegl-dev to RDEPENDS_packagegroup-r…

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests-x11.bb
@@ -8,6 +8,7 @@ PACKAGES = "\
     "
 RDEPENDS_packagegroup-rpb-tests-x11 = "\
     gst-devtools \
+    libegl-dev \
     opengl-es-cts \
     parallel-deqp-runner \
     piglit \


### PR DESCRIPTION
…pb-tests-x11

opengl-es-cts tries to load libEGL.so (rather than libEGL.so.1), so
install libegl-dev to include libEGL.so symlink.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>