### PR TITLE
Remove usermod -aG weston-launch linaro

### DIFF
--- a/recipes-samples/images/rpb-weston-image.bb
+++ b/recipes-samples/images/rpb-weston-image.bb
@@ -15,5 +15,5 @@ CORE_IMAGE_BASE_INSTALL += " \
 "
 
 EXTRA_USERS_PARAMS += "\
-usermod -a -G weston-launch,video linaro; \
+usermod -a -G video linaro; \
 "


### PR DESCRIPTION
Fixes

    Exception: bb.process.ExecutionError: Execution of '/builds/db410c-yocto/build-rpb-wayland/tmp-rpb_wayland-glibc/work/dragonboard_410c-linaro-linux/rpb-weston-image/1.0-r0/temp/run.set_user_group.55316' failed with exit code 1:
    usermod: group 'weston-launch' does not exist