### PR TITLE
[sumo] packagegroup-rpb-tests: Drop more LKFT testsuites and tools

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -39,10 +39,7 @@ RDEPENDS_packagegroup-rpb-tests-python3 = "\
 SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console (no graphics)"
 RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-speakertest \
-    cpupower \
-    libhugetlbfs-tests \
     ltp \
-    s-suite \
     stress-ng \
     ptest-runner \
     "


### PR DESCRIPTION
They now live in meta-lkft's packagegroup.