### PR TITLE
recipes-samples: packagegroup-rpb-tests conditional includes cpupower

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -31,7 +31,7 @@ SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console 
 RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
-    cpupower \
+    ${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-dummy", "", "cpupower", d)} \
     git \
     i2c-tools \
     igt-gpu-tools-tests \


### PR DESCRIPTION
The cpupower recipe compiles code inside work-shared of Linux kernel if
linux-dummy is selected as default provider this code is not available,
so not include it when linux-dummy is selected.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>