### PR TITLE
packagegroup-rpb-tests: Remove libhugetlbfs-tests for now

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -37,7 +37,6 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     igt-gpu-tools-tests \
     libdrm-tests \
     libgpiod-tools \
-    libhugetlbfs-tests \
     ltp \
     net-snmp \
     s-suite \


### PR DESCRIPTION
Is not supported needs port to glibc 2.34+.

Fixes,

https://ci.linaro.org/job/lt-qcom-linux-testimages/MACHINE=qemuarm,label=docker-buster-amd64/885/console

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>