### PR TITLE
rpb.inc: switch GCCVERSION to 10.3

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,7 +28,7 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "arm-10.2"
+GCCVERSION ?= "arm-10.3"
 
 DISTRO_FEATURES:append = " opengl pam systemd ptest vulkan"
 DISTRO_FEATURES:remove = "3g sysvinit"


### PR DESCRIPTION
meta-arm has upgraded provided toolchain from 10.2 to 10.3. Update
GCCVERSION accordingly.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>