### PR TITLE
packagegroup-rpb-tests: include cryptsetup

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,6 +32,7 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
     ${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-dummy", "", "cpupower", d)} \
+    cryptsetup \
     git \
     i2c-tools \
     igt-gpu-tools-tests \


### PR DESCRIPTION
This can be used to sanity crypto tests and benchmarks.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>