### PR TITLE
packagegroup-rpb-tests: include cryptsetup

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,6 +32,7 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
     cpupower \
+    cryptsetup \
     git \
     i2c-tools \
     igt-gpu-tools-tests \


### PR DESCRIPTION
This can be used to sanity crypto tests and benchmarks.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
(cherry picked from commit 7d768a7a5d110034238dda7056c0bd98b633c5d5)