### PR TITLE
packagegroup-rpb-tests: add several new test packages

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,17 +32,26 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
     ${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-dummy", "", "cpupower", d)} \
+    crash \
     cryptsetup \
+    dhrystone \
     git \
     i2c-tools \
     igt-gpu-tools-tests \
+    iozone3 \
     libdrm-tests \
     libgpiod-tools \
+    lmbench \
     ltp \
+    mbw \
     net-snmp \
     s-suite \
     stress-ng \
+    sysbench \
     ptest-runner \
+    tinymembench \
+    tiobench \
     usbutils \
+    whetstone \
     "
 RDEPENDS:packagegroup-rpb-tests-console:remove:libc-musl = "igt-gpu-tools-tests"


### PR DESCRIPTION
console only test should not be dependent on network avaiability
to git clone test packages, as several boards might have non-functional
/ broken ethernet interfaces.

This patch adds several test packages which can be of use for
console-test images:
 * crash, cryptsetup
 * Performance check related: dhrystone, iozone3, lmbench, mbw, sysbench,
                              tinymembench, tiobench, whetstone.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>