### PR TITLE
96boards-artwork: specify branch

### DIFF
--- a/recipes-samples/artwork/96boards-artwork_git.bb
+++ b/recipes-samples/artwork/96boards-artwork_git.bb
@@ -4,7 +4,7 @@ SECTION = "x11/graphics"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
-SRC_URI = "git://github.com/96boards/96boards-artwork;protocol=https"
+SRC_URI = "git://github.com/96boards/96boards-artwork;protocol=https;branch=master"
 SRCREV = "066d5b151cbd0d3595a16e5f28762d78389d3548"
 PV = "0.0+git${SRCPV}"
 


### PR DESCRIPTION
Specify default branch in SRC_URI to fix the following warning:

WARNING: URL: git://github.com/96boards/96boards-artwork;protocol=https does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>