### PR TITLE
recipes-samples/packagegroup-rpb.bb: Add ntp package

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -29,6 +29,7 @@ RDEPENDS:packagegroup-rpb = "\
     kernel-modules \
     networkmanager \
     networkmanager-nmtui \
+    ntp \
     openssh-sftp-server \
     ${@bb.utils.contains("MACHINE_FEATURES", "optee", d.getVar("OPTEE_PACKAGES", True), "", d)} \
     python3-misc \


### PR DESCRIPTION
Some boards doesn't has a battery to store the datetime so
add ntp to sync when connect to Internet.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>