### PR TITLE
packagegroup-rpb-tests: Add gps related test packages

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -36,6 +36,8 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     cryptsetup \
     dhrystone \
     git \
+    gps-utils \
+    gpsd \
     i2c-tools \
     igt-gpu-tools-tests \
     iozone3 \

--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -9,8 +9,6 @@ SUMMARY:packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS:packagegroup-rpb-weston = "\
     clutter-1.0-examples \
     ffmpeg \
-    gps-utils \
-    gpsd \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -11,8 +11,6 @@ RDEPENDS:${PN} = "\
     feh-autostart \
     ffmpeg \
     glmark2 \
-    gps-utils \
-    gpsd \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -20,6 +20,8 @@ RDEPENDS:packagegroup-rpb = "\
     cpufrequtils \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "docker", d)} \
     file \
+    gps-utils \
+    gpsd \
     gptfdisk \
     hostapd \
     htop \


### PR DESCRIPTION
Add gps related test packages (gps, gps-utils and ncurses)
to packagegroup-rpb-tests.

This allows a quick test of the gps interface (if available)
with the rpb test images.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>