### PR TITLE
packagegroup-rpb{-tests}: Add gps related test packages to honister

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -36,6 +36,8 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     cryptsetup \
     dhrystone \
     git \
+    gps-utils \
+    gpsd \
     i2c-tools \
     igt-gpu-tools-tests \
     iozone3 \

--- a/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-weston.bb
@@ -9,8 +9,6 @@ SUMMARY:packagegroup-rpb-weston = "Apps that can be used in Weston Desktop"
 RDEPENDS:packagegroup-rpb-weston = "\
     clutter-1.0-examples \
     ffmpeg \
-    gps-utils \
-    gpsd \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \

--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -11,8 +11,6 @@ RDEPENDS:${PN} = "\
     feh-autostart \
     ffmpeg \
     glmark2 \
-    gps-utils \
-    gpsd \
     gstreamer1.0-plugins-bad-meta \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \

--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -20,6 +20,8 @@ RDEPENDS:packagegroup-rpb = "\
     cpufrequtils \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "docker", d)} \
     file \
+    gps-utils \
+    gpsd \
     gptfdisk \
     hostapd \
     htop \


### PR DESCRIPTION
Add gps related test packages (gps, gps-utils)
to packagegroup-rpb-tests.

This allows a quick test of the gps interface (if available)
with the rpb test images.

While at it, also make a change to make sure that 'packagegroup-rpb-*.bb'
files inherit the same from the base 'packagegroup-rpb.bb' itself.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit 0f0c85e3e6dce0a8abaa719cb9f8826fcaa4824e)
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
(cherry picked from commit b9a2e725a9b887998278b9d9f299ea22b3365b69)