### PR TITLE
packagegroup-rpb{-tests}: Add pciutils test package

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -50,6 +50,7 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     s-suite \
     stress-ng \
     sysbench \
+    pciutils \
     pm-qa \
     ptest-runner \
     tinymembench \


### PR DESCRIPTION
Add pciutils (which provides lspci like commands) to
packagegroup-rpb-tests.

This allows a quick test of the PCIe interface(s)
(if available) with the rpb test images.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>