### PR TITLE
packagegroup-rpb{-tests}: Add pciutils test package

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -51,6 +51,7 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     s-suite \
     stress-ng \
     sysbench \
+    pciutils \
     pm-qa \
     ptest-runner \
     tinymembench \


### PR DESCRIPTION
Add pciutils (which provides lspci like commands) to
packagegroup-rpb-tests.

This allows a quick test of the PCIe interface(s)
(if available) with the rpb test images.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit e5d58adcd251f03b7b1bf277e1acc6ba7909eeb0)