### PR TITLE
packagegroup-rpb{-tests}: Add {c}make test package

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -32,6 +32,7 @@ RDEPENDS:packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
     ${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-dummy", "", "cpupower", d)} \
+    cmake \
     crash \
     cryptsetup \
     dhrystone \


### PR DESCRIPTION
Add {c}make to packagegroup-rpb-tests.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>