### PR TITLE
packagegroup-rpb{-tests}: Add iperf3 and netperf test packages

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -43,12 +43,14 @@ RDEPENDS_packagegroup-rpb-tests-console = "\
     i2c-tools \
     igt-gpu-tools-tests \
     iozone3 \
+    iperf3 \
     libdrm-tests \
     libgpiod-tools \
     libhugetlbfs-tests \
     lmbench \
     ltp \
     mbw \
+    netperf \
     net-snmp \
     s-suite \
     stress-ng \


### PR DESCRIPTION
Add iperf3 and netperf test packages (which allow determining
performance figures for an ethernet interface) to
packagegroup-rpb-tests.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>