### PR TITLE
rpb.inc: enable uninative usage

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -56,3 +56,6 @@ IMAGE_FSTYPES:append:beaglebone = " ext4.gz"
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"
+
+require conf/distro/include/yocto-uninative.inc
+INHERIT += "uninative"


### PR DESCRIPTION
This decouples build system from the host distribution. This would make
sharing sstate even more practical.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>