### PR TITLE
packagegroup-rpb{-tests}: Add android-tools-conf package

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-tests.bb
@@ -31,6 +31,7 @@ SUMMARY_packagegroup-rpb-tests-console = "Test apps that can be used in console 
 RDEPENDS_packagegroup-rpb-tests-console = "\
     alsa-utils-alsaucm \
     alsa-utils-speakertest \
+    android-tools-conf \
     cpupower \
     cmake \
     crash \


### PR DESCRIPTION
Add android-tools-conf package which allows
configuring the platform as a USB ADB gadget.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>