### PR TITLE
96boards-artwork: use SPDX identifier for the license

### DIFF
--- a/recipes-samples/artwork/96boards-artwork_git.bb
+++ b/recipes-samples/artwork/96boards-artwork_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "96boards artwork files"
 HOMEPAGE = "https://www.96boards.org/"
 SECTION = "x11/graphics"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 SRC_URI = "git://github.com/96boards/96boards-artwork;protocol=https;branch=master"


### PR DESCRIPTION
Fix the following warning by OpenEmbedded QA:

WARNING: 96boards-artwork-0.0+gitAUTOINC+066d5b151c-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPLv2 [obsolete-license]