### PR TITLE
rpb.inc: remove -fcanon-prefix-map from DEBUG_PREFIX_MAP

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -29,6 +29,8 @@ def get_multilib_handler(d):
 #include ${@get_multilib_handler(d)}
 
 GCCVERSION ?= "arm-12.2"
+# Remove gcc specific -fcanon-prefix-map option, added in gcc-13+
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 DISTRO_FEATURES:append = " opengl pam systemd ptest vulkan"
 DISTRO_FEATURES:remove = "3g sysvinit"


### PR DESCRIPTION
oe-core has added the '-fcanon-prefix-map' option to DEBUG_PREFIX_MAP. However this option is only supported since gcc-13, while RPB defaults to ARM gcc 12. Remove this option for now.