### PR TITLE
rpb.inc: stop using ARM toolchain

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -28,10 +28,6 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-GCCVERSION ?= "arm-12.2"
-# Remove gcc specific -fcanon-prefix-map option, added in gcc-13+
-DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
-
 DISTRO_FEATURES:append = " opengl pam systemd ptest vulkan"
 DISTRO_FEATURES:remove = "3g sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"


### PR DESCRIPTION
There is little point in using ARM toolchain, the main (FSF) is pretty good enough. Stop using the ARM toolchain and switch to the default so that we do not diverge from main OE/Yocto and (potentially) don't have to cope with toolchain/codegen bugs which are not present/tested/handled by the rest of the community.