### PR TITLE
packagegroup-rpb-x11: drop xsetmode

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-x11.bb
@@ -39,6 +39,5 @@ RDEPENDS:${PN}-utils = "\
     xrandr \
     xrdb \
     xrefresh \
-    xsetmode \
     xsetroot \
 "


### PR DESCRIPTION
The xsetmode package was dropped from meta-oe, drop it here too.