### PR TITLE
distro: rpb: set INIT_MANAGER as systemd

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -13,6 +13,10 @@ require conf/distro/include/egl.inc
 # to make the python below work. Local, site and auto.conf will override it.
 TCMODE ?= "default"
 
+# defaultsetup.conf does include the right file for the init manager setup,
+# force it here to systemd in order to always have the right configuration.
+INIT_MANAGER = "systemd"
+
 # Enable multilib conditionally, only for aarch64 with default toolchain combination
 # Other combinations aren't supported
 def get_multilib_handler(d):
@@ -28,9 +32,8 @@ def get_multilib_handler(d):
 # It is the case when we don't want multilib enabled (e.g. on 32bit machines).
 #include ${@get_multilib_handler(d)}
 
-DISTRO_FEATURES:append = " opengl pam systemd ptest vulkan"
-DISTRO_FEATURES:remove = "3g sysvinit"
-VIRTUAL-RUNTIME_init_manager = "systemd"
+DISTRO_FEATURES:append = " opengl pam ptest vulkan"
+DISTRO_FEATURES:remove = "3g"
 PACKAGECONFIG:append:pn-systemd = " resolved networkd"
 PACKAGECONFIG:append:pn-qtbase = " gles2 fontconfig examples"
 PACKAGECONFIG:remove:pn-gpsd = "qt"


### PR DESCRIPTION
Commit [fa8c59c](https://github.com/openembedded/openembedded-core/commit/802e853eeddf16d73db1900546cc5f045d1fb7ed) in openembedded-core makes usrmerge a requirement, in order to make sure it still builds with older releases set the INIT_MANAGER variable so the configuration is always done right from the defaultsetup.conf loaded after the distro conf.

Log of build failure:
ERROR: Nothing RPROVIDES 'udev' (...)
systemd RPROVIDES udev but was skipped: missing required distro feature 'usrmerge' (not in DISTRO_FEATURES)
eudev RPROVIDES udev but was skipped: conflicting distro feature 'systemd' (in DISTRO_FEATURES)
NOTE: Runtime target 'udev' is unbuildable, removing... 
Missing or unbuildable dependency chain was: ['udev']