### PR TITLE
rpb.inc: re-enable nmtui in networkmanager

### DIFF
--- a/conf/distro/include/rpb.inc
+++ b/conf/distro/include/rpb.inc
@@ -40,6 +40,7 @@ PACKAGECONFIG:remove:pn-gpsd = "qt"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " kms"
 PACKAGECONFIG:append:pn-ffmpeg = " sdl2"
 PACKAGECONFIG:append:pn-igt-gpu-tools = " chamelium"
+PACKAGECONFIG:append:pn-networkmanager = " nmtui"
 
 PREFERRED_PROVIDER_iasl-native = "acpica-native"
 PREFERRED_PROVIDER_iasl = "acpica"


### PR DESCRIPTION
The RPB images depend on the nmtui package, which got hidden behind the PACKAGECONIG. Reenable correspondign option to unbreak our images.