### PR TITLE
xserver-xorg: reenable xvfb

### DIFF
--- a/recipes-overlayed/xserver-xorg/xserver-xorg_%.bbappend
+++ b/recipes-overlayed/xserver-xorg/xserver-xorg_%.bbappend
@@ -1,0 +1,3 @@
+# enable XvFB for gst-validate
+
+PACKAGECONFIG:append = " xvfb"


### PR DESCRIPTION
XvFB is necessary for gst-validate, reenable it.