### PR TITLE
packagegroup-rpb: drop docker for now

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb.bb
@@ -18,7 +18,6 @@ RDEPENDS:packagegroup-rpb = "\
     alsa-utils-aplay \
     coreutils \
     cpufrequtils \
-    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "docker", d)} \
     file \
     gps-utils \
     gpsd \


### PR DESCRIPTION
In the commit cc4ec43a2b65 ("go: Drop fork of unpack code, mandate GO_SRCURI_DESTSUFFIX") OE-Core has dropped custom do_unpack implementation in favour of forcing Go recipes to use destsuffix option in SRC_URI. While Bruce is struggling with getting the meta-virt to work in the changed environment ([1]), disable docker dependency for now.

[1] https://lists.yoctoproject.org/g/meta-virtualization/message/8769