### PR TITLE
image-adbd: move usb-debugging-enabled flag file to /etc

### DIFF
--- a/classes/image-adbd.bbclass
+++ b/classes/image-adbd.bbclass
@@ -7,7 +7,7 @@ IMAGE_FEATURES[validitems] += "enable-adbd"
 PACKAGE_INSTALL:append = " ${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], 'android-tools-adbd', '',d)} "
 
 enable_adbd_at_boot () {
-	touch ${IMAGE_ROOTFS}/var/usb-debugging-enabled
+	touch ${IMAGE_ROOTFS}/etc/usb-debugging-enabled
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], 'enable_adbd_at_boot; ', '',d)}"


### PR DESCRIPTION
Location of the file that systemd uses to check whether to start adbd or not has been updated from /var to /etc in android-tools-adbd.service. Move the created usb-debugging-enabled flag file from /var/usb-debugging-enabled to /etc/usb-debugging-enabled.