### PR TITLE
rpb-minimal-image: replace debug-tweaks feature

### DIFF
--- a/recipes-samples/images/rpb-minimal-image.bb
+++ b/recipes-samples/images/rpb-minimal-image.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Minimal image"
 
-IMAGE_FEATURES += "splash tools-debug debug-tweaks enable-adbd"
+IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging"
 
 LICENSE = "MIT"
 


### PR DESCRIPTION
The `debug-tweaks` IMAGE_FEATURE has been dropped in favour of explicitly using corresponding features. Replace it with the suggested list of features.