### PR TITLE
rpb-minimal-image: restore enable-adbd feature

### DIFF
--- a/recipes-samples/images/rpb-minimal-image.bb
+++ b/recipes-samples/images/rpb-minimal-image.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Minimal image"
 
-IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging"
+IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging enable-adbd"
 
 LICENSE = "MIT"
 


### PR DESCRIPTION
Bring back the "enable-adbd" feature dropped in the last commit.

Fixes: ceaef9214090 ("rpb-minimal-image: replace debug-tweaks feature")