### PR TITLE
layer.conf: declare compatibility with walnascar

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_COLLECTIONS += "meta-rpb"
 BBFILE_PATTERN_meta-rpb := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpb = "8"
 
-LAYERSERIES_COMPAT_meta-rpb = "styhead"
+LAYERSERIES_COMPAT_meta-rpb = "styhead walnascar"
 
 LAYERDEPENDS_meta-rpb = "openembedded-layer meta-python networking-layer \
                          filesystems-layer virtualization-layer gnome-layer"


### PR DESCRIPTION
OE-Core layer has stopped listing styhead. Add the next release name, walnascar, to LAYERSERIES_COMPAT.